### PR TITLE
fix: prevent the last image of camera from being cropped

### DIFF
--- a/src/components/Dashboard/CameraCard.tsx
+++ b/src/components/Dashboard/CameraCard.tsx
@@ -20,7 +20,8 @@ export const CameraCard = ({ camera }: CameraCardType) => {
   return (
     <Card sx={{ height: '100%', borderRadius: 2 }}>
       <CardMedia
-        sx={{ height: 250 }}
+        component="img"
+        sx={{ objectFit: 'contain' }}
         image={camera.last_image_url ?? noImage}
         title={t('titleImage')}
       />


### PR DESCRIPTION
- Edit the size of the image to prevent from being cropped or resized

Before : 
<img width="1508" height="781" alt="Capture d’écran 2025-07-18 à 17 31 02" src="https://github.com/user-attachments/assets/caebae50-fa7b-4147-8d44-bdac1785763d" />

After
<img width="1508" height="781" alt="Capture d’écran 2025-07-18 à 17 30 32" src="https://github.com/user-attachments/assets/8c8ada6b-9ea7-411a-be12-cb2e992efd83" />
