### PR TITLE
Fix auth always redirecting to dashboard when logged in

### DIFF
--- a/src/context/AuthProvider.tsx
+++ b/src/context/AuthProvider.tsx
@@ -9,7 +9,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const [token, setToken] = useState<string | null>(() => {
-    // Initialize token state with the value from localStorage immediately
     const existingToken = getAuthToken();
     if (existingToken) {
       instance.defaults.headers.common.Authorization = `Bearer ${existingToken}`;

--- a/src/context/AuthProvider.tsx
+++ b/src/context/AuthProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import { getToken } from '../services/auth';
 import { instance } from '../services/axios';
@@ -8,15 +8,14 @@ import { AuthContext } from './AuthContext';
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const [token, setToken] = useState<string | null>(null);
-
-  useEffect(() => {
+  const [token, setToken] = useState<string | null>(() => {
+    // Initialize token state with the value from localStorage immediately
     const existingToken = getAuthToken();
     if (existingToken) {
       instance.defaults.headers.common.Authorization = `Bearer ${existingToken}`;
-      setToken(existingToken);
     }
-  }, []);
+    return existingToken;
+  });
 
   const login = useCallback(
     async (username: string, password: string) => {


### PR DESCRIPTION
Fixing a bug: When on /alerts page and clicking refresh, we would be redirected to Dashboard.
Same when opening a link to /alerts

This is caused by a race condition with useEffect:
1. go to /alerts page
2. refresh
3. AuthProvider runs and check auth
4. in first render, token is null 
5. ProtectedRoute sees a null token and redirect to Login page
6. Login page render but this time the token is resolved 
7. Navigates to Dashboard

Fix:
We remove useEffect in the PR and set the state directly from the localStorage auth_token. This works since it's a synchronous method. 
The token is never null and we don't go to the Login page