### PR TITLE
Fix map camera size rendering

### DIFF
--- a/src/components/Dashboard/CamerasMap.tsx
+++ b/src/components/Dashboard/CamerasMap.tsx
@@ -1,5 +1,5 @@
 import L from 'leaflet';
-import { MapContainer, Marker, Popup, TileLayer, useMap } from 'react-leaflet';
+import { MapContainer, Marker, Popup, TileLayer } from 'react-leaflet';
 
 import siteIcon from '@/assets/site-icon.png';
 
@@ -18,15 +18,15 @@ interface AlertMap {
 }
 
 //TODO : fix the partial loading of the map to remove this patch component
-const ComponentResize = () => {
-  const map = useMap();
+// const ComponentResize = () => {
+//   const map = useMap();
 
-  setTimeout(() => {
-    map.invalidateSize();
-  }, 0);
+//   setTimeout(() => {
+//     map.invalidateSize();
+//   }, 0);
 
-  return null;
-};
+//   return null;
+// };
 
 const AlertMap = ({ cameras }: AlertMap) => {
   const bounds = L.latLngBounds(cameras.map((c) => [c.lat, c.lon]));
@@ -42,7 +42,7 @@ const AlertMap = ({ cameras }: AlertMap) => {
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
-        <ComponentResize />
+        {/* <ComponentResize /> */}
         {cameras.map((camera) => {
           return (
             <Marker

--- a/src/components/Dashboard/DashboardContainer.tsx
+++ b/src/components/Dashboard/DashboardContainer.tsx
@@ -70,22 +70,26 @@ export const DashboardContainer = ({
                   isRefreshing={isRefreshing}
                 />
               </Stack>
-              <Box hidden={indexTab !== 0}>
-                <ViewCards
-                  lastUpdate={lastUpdate}
-                  isRefreshing={isRefreshing}
-                  invalidateAndRefreshData={invalidateAndRefreshData}
-                  cameraList={cameraList}
-                />
-              </Box>
-              <Box hidden={indexTab !== 1}>
-                <ViewMap
-                  lastUpdate={lastUpdate}
-                  isRefreshing={isRefreshing}
-                  invalidateAndRefreshData={invalidateAndRefreshData}
-                  cameraList={cameraList}
-                />
-              </Box>
+              {indexTab === 0 && (
+                <Box>
+                  <ViewCards
+                    lastUpdate={lastUpdate}
+                    isRefreshing={isRefreshing}
+                    invalidateAndRefreshData={invalidateAndRefreshData}
+                    cameraList={cameraList}
+                  />
+                </Box>
+              )}
+              {indexTab === 1 && (
+                <Box>
+                  <ViewMap
+                    lastUpdate={lastUpdate}
+                    isRefreshing={isRefreshing}
+                    invalidateAndRefreshData={invalidateAndRefreshData}
+                    cameraList={cameraList}
+                  />
+                </Box>
+              )}
             </Box>
           )}
         </>

--- a/src/components/Dashboard/ViewMap.tsx
+++ b/src/components/Dashboard/ViewMap.tsx
@@ -1,4 +1,4 @@
-import { Grid, Stack, useTheme } from '@mui/material';
+import { Grid, Stack } from '@mui/material';
 
 import type { CameraType } from '../../services/camera';
 import { useIsMobile } from '../../utils/useIsMobile';
@@ -13,7 +13,6 @@ interface ViewMapProps {
 }
 
 export const ViewMap = ({ cameraList }: ViewMapProps) => {
-  const theme = useTheme();
   const isMobile = useIsMobile();
 
   return (
@@ -25,7 +24,6 @@ export const ViewMap = ({ cameraList }: ViewMapProps) => {
           overflowY: isMobile ? 'unset' : 'auto',
           height: 'calc(100vh - 64px - 81px)', // To get scroll on the cards list only (= 100% - topbar height - tabs)
         }}
-        bgcolor={theme.palette.customBackground.light}
       >
         <Stack spacing={{ xs: 1, sm: 2 }}>
           {cameraList.map((camera) => (


### PR DESCRIPTION
- Don't render map if not on tab

This change improves performance by preventing unnecessary map rendering when the user is not on the map tab.