### PR TITLE
fix: time overlap on screen

### DIFF
--- a/src/components/Alerts/AlertDetails/AlertImagesPlayer.tsx
+++ b/src/components/Alerts/AlertDetails/AlertImagesPlayer.tsx
@@ -1,14 +1,6 @@
 import PauseIcon from '@mui/icons-material/Pause';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
-import {
-  Box,
-  Grid,
-  IconButton,
-  Slider,
-  Typography,
-  useMediaQuery,
-  useTheme,
-} from '@mui/material';
+import { Box, IconButton, Slider, Stack, useTheme } from '@mui/material';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import type { DetectionType } from '../../../services/alerts';
@@ -32,17 +24,19 @@ export const AlertImagesPlayer = ({
     useState<DetectionType | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const theme = useTheme();
-  const isLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
   const { t } = useTranslationPrefix('alerts');
 
   const marks = useMemo(
     () =>
-      detections.map((d) => ({
+      detections.map((d, i) => ({
         value: convertStrToEpoch(d.created_at),
         id: d.id,
-        label: isLargeScreen ? formatToTime(d.created_at) : null,
+        label:
+          i == 0 || i == detections.length - 1
+            ? formatToTime(d.created_at)
+            : null,
       })),
-    [detections, isLargeScreen]
+    [detections]
   );
 
   const displayNextImage = useCallback(() => {
@@ -104,59 +98,50 @@ export const AlertImagesPlayer = ({
   };
 
   return (
-    <Grid container direction="column" spacing={1}>
+    <>
       {selectedDetection && (
-        <>
-          <Grid>
-            <DetectionImageWithBoundingBox
-              sequenceId={sequenceId}
-              selectedDetection={selectedDetection}
-            />
-          </Grid>
-          <Grid container alignItems="center" spacing={2}>
-            <Grid>
-              <IconButton
-                onClick={onClickPausePlay}
-                aria-label={t(isPlaying ? 'buttonPause' : 'buttonPlay')}
-                size="large"
-                sx={{ border: `1px solid ${theme.palette.grey[500]}` }}
-              >
-                {isPlaying ? <PauseIcon /> : <PlayArrowIcon />}
-              </IconButton>
-            </Grid>
-            <Grid flex={1}>
-              <Box
-                sx={{ width: '100%', padding: isLargeScreen ? '0 30px' : 0 }}
-              >
-                <Slider
-                  aria-valuetext={formatToTime(selectedDetection.created_at)}
-                  value={convertStrToEpoch(selectedDetection.created_at)}
-                  onChange={onChangeSlider}
-                  min={Math.min(...marks.map((mark) => mark.value))}
-                  max={Math.max(...marks.map((mark) => mark.value))}
-                  step={null}
-                  valueLabelDisplay="off"
-                  marks={marks}
-                  sx={{
-                    verticalAlign: 'middle',
-                    '& .MuiSlider-markLabel': {
-                      margin: 0,
-                      fontSize: '0.8rem',
-                    },
-                  }}
-                />
-              </Box>
-            </Grid>
-            {!isLargeScreen && (
-              <Grid>
-                <Typography>
-                  {formatToTime(selectedDetection.created_at)}
-                </Typography>
-              </Grid>
-            )}
-          </Grid>
-        </>
+        <Stack direction="column" spacing={1}>
+          <DetectionImageWithBoundingBox
+            sequenceId={sequenceId}
+            selectedDetection={selectedDetection}
+          />
+
+          <Stack direction="row" alignItems="center" spacing={2}>
+            <IconButton
+              onClick={onClickPausePlay}
+              aria-label={t(isPlaying ? 'buttonPause' : 'buttonPlay')}
+              size="large"
+              sx={{ border: `1px solid ${theme.palette.grey[500]}` }}
+            >
+              {isPlaying ? <PauseIcon /> : <PlayArrowIcon />}
+            </IconButton>
+            <Box sx={{ flexGrow: 1, width: '100%', mr: 2, px: 3, pt: 3 }}>
+              <Slider
+                value={convertStrToEpoch(selectedDetection.created_at)}
+                onChange={onChangeSlider}
+                min={Math.min(...marks.map((mark) => mark.value))}
+                max={Math.max(...marks.map((mark) => mark.value))}
+                step={null}
+                valueLabelDisplay="on"
+                valueLabelFormat={formatToTime(selectedDetection.created_at)}
+                marks={marks}
+                sx={{
+                  verticalAlign: 'middle',
+                  '& .MuiSlider-markLabel': {
+                    m: 0,
+                    fontSize: '0.8rem',
+                  },
+                  '& .MuiSlider-valueLabel': {
+                    m: 0,
+                    backgroundColor: theme.palette.primary.main,
+                    fontSize: '0.8rem',
+                  },
+                }}
+              />
+            </Box>
+          </Stack>
+        </Stack>
       )}
-    </Grid>
+    </>
   );
 };


### PR DESCRIPTION
**What it was before :** 
On large screen, every point was displayed with the hour. It caused overlap between the label
On small screen, only the current point was dispalyed
<img width="1129" height="698" alt="Capture d’écran 2025-08-17 à 14 59 38" src="https://github.com/user-attachments/assets/4dce62d6-20e1-4caf-8e4a-02ee5a36dcc9" />
<img width="232" height="698" alt="Capture d’écran 2025-08-17 à 15 00 11" src="https://github.com/user-attachments/assets/35cf8b33-f119-4fd6-a44e-b3e29ed76c94" />


**What is done now**
On every size of screen, only the first and the last is permanently displayed.
A kind of tooltip is also always displayed to indicate the current time 
<img width="1129" height="698" alt="Capture d’écran 2025-08-17 à 14 58 13" src="https://github.com/user-attachments/assets/5b2dbe55-b819-403f-98e3-756d231d85e8" />
<img width="232" height="698" alt="Capture d’écran 2025-08-17 à 15 00 33" src="https://github.com/user-attachments/assets/d7823501-b63f-48b7-ba92-5b7e4662c16c" />

In the code, the modifications are : 
- replace Grid by a much lighter Stack when needed (it changes the whole component tree, sorry)
- change the default style of the tooltip (in the sx props of the slider)
- change the space around the slider to give some space for the tooltip (in the sx of the box containing the slider)