### PR TITLE
feat: style selectedCard of dashboard camera

### DIFF
--- a/src/components/Alerts/AlertsList/AlertCard.tsx
+++ b/src/components/Alerts/AlertsList/AlertCard.tsx
@@ -33,7 +33,7 @@ export const AlertCard = ({
   const { t } = useTranslationPrefix('alerts');
 
   return (
-    <Card sx={{ borderRadius: '2px' }}>
+    <Card>
       <CardActionArea
         onClick={setActive}
         data-active={isActive ? '' : undefined}

--- a/src/components/Dashboard/CameraCard.tsx
+++ b/src/components/Dashboard/CameraCard.tsx
@@ -47,18 +47,18 @@ export const CameraCard = ({
   };
 
   return (
-    <Card sx={{ borderRadius: 2, flexShrink: 0 }} ref={ref}>
+    <Card
+      sx={{ flexShrink: 0, borderRadius: isHorizontal ? undefined : '8px' }}
+      ref={ref}
+    >
       <CardActionArea
         data-active={isSelected ? '' : undefined}
         onClick={setSelected}
         sx={(theme) => ({
           height: '100%',
-          '&:hover': {
-            backgroundColor: theme.palette.customBackground.dark,
-          },
           '&[data-active]': {
-            backgroundColor: theme.palette.primary.light,
-            color: theme.palette.primary.contrastText,
+            backgroundColor: 'action.selected',
+            borderLeft: `3px solid ${theme.palette.primary.light}`,
             '&:hover': {
               backgroundColor: 'action.selectedHover',
             },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -144,5 +144,12 @@ export const theme = createTheme({
         },
       },
     },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: '2px',
+        },
+      },
+    },
   },
 });


### PR DESCRIPTION
Add same style as the alert card when selected
Change only the color border to avoid association with "error"
<img width="914" height="734" alt="Capture d’écran 2025-08-31 à 10 54 07" src="https://github.com/user-attachments/assets/32cd2e2a-e910-41a3-8ed3-d47a6201a571" />


Reminder:  Alerts look like this : 
<img width="389" height="734" alt="Capture d’écran 2025-08-31 à 10 55 29" src="https://github.com/user-attachments/assets/ea85b334-76a5-498a-a55d-7ce77d4c5201" />
