### PR TITLE
feat: improve navigation (change style and labels in topbar, add 404 and error boundaries page)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { Topbar } from './components/Topbar/Topbar';
 import { AuthProvider } from './context/AuthProvider';
 import { AlertsPage } from './pages/AlertsPage';
 import { DashboardPage } from './pages/DashboardPage';
+import { ErrorPage } from './pages/ErrorPage';
 import { HistoryPage } from './pages/HistoryPage';
 import { LoginPage } from './pages/LoginPage';
 
@@ -30,14 +31,16 @@ const App = () => {
             <Topbar />
             <Stack overflow={'hidden'} flexGrow={1}>
               <Routes>
-                <Route index element={<Navigate to={DEFAULT_ROUTE} />} />
-                <Route path="/login" element={<LoginPage />}></Route>
-
-                {/* Routes under this cannot be accessed without being logged in */}
-                <Route element={<ProtectedRoute />}>
-                  <Route path="/alerts" element={<AlertsPage />}></Route>
-                  <Route path="/dashboard" element={<DashboardPage />}></Route>
-                  <Route path="/history" element={<HistoryPage />}></Route>
+                <Route errorElement={<ErrorPage />}>
+                  <Route index element={<Navigate to={DEFAULT_ROUTE} />} />
+                  <Route path="/login" element={<LoginPage />} />
+                  {/* Routes under this cannot be accessed without being logged in */}
+                  <Route element={<ProtectedRoute />}>
+                    <Route path="/alerts" element={<AlertsPage />} />
+                    <Route path="/dashboard" element={<DashboardPage />} />
+                    <Route path="/history" element={<HistoryPage />} />
+                  </Route>
+                  <Route path="*" element={<ErrorPage is404 />} />
                 </Route>
               </Routes>
             </Stack>

--- a/src/components/Topbar/DesktopTopbar.tsx
+++ b/src/components/Topbar/DesktopTopbar.tsx
@@ -1,4 +1,4 @@
-import { AppBar, Grid, Toolbar } from '@mui/material';
+import { AppBar, Stack, Toolbar } from '@mui/material';
 
 import logo from '@/assets/logo.svg';
 
@@ -17,28 +17,33 @@ export const DesktopTopbar = () => {
     <>
       <AppBar>
         <Toolbar disableGutters>
-          <Grid container justifyContent="space-between" sx={{ flexGrow: 1 }}>
-            <Grid container spacing={5} sx={{ paddingLeft: '12px' }}>
+          <Stack
+            direction="row"
+            justifyContent="space-between"
+            flexGrow={1}
+            alignItems="center"
+            px={2}
+          >
+            <Stack direction="row" spacing={5} alignItems="center">
               <img height="30px" src={logo} alt="Logo" />
               {isLoggedIn && (
-                <Grid container spacing={4} alignItems="center">
+                <Stack direction="row" spacing={2}>
                   <NavigationLink path="/alerts" label={t('alerts')} />
                   <NavigationLink path="/dashboard" label={t('dashboard')} />
                   <NavigationLink path="/history" label={t('history')} />
-                </Grid>
+                </Stack>
               )}
-            </Grid>
-            <Grid
-              container
+            </Stack>
+            <Stack
+              direction="row"
               spacing={2}
               alignItems="center"
               justifyContent="space-around"
-              paddingRight="1rem"
             >
               <LanguageSwitcher />
               {isLoggedIn && <LogoutButton />}
-            </Grid>
-          </Grid>
+            </Stack>
+          </Stack>
         </Toolbar>
       </AppBar>
       {/* Empty toolbar to account for the above one with fixed position */}

--- a/src/components/Topbar/NavigationLink.tsx
+++ b/src/components/Topbar/NavigationLink.tsx
@@ -15,9 +15,15 @@ export const NavigationLink = ({ path, label }: NavigationLinkProps) => {
         <Typography
           color={theme.palette.primary.contrastText}
           sx={{
-            fontWeight: 500,
+            ...(isActive
+              ? {
+                  fontWeight: 500,
+                  backgroundColor: theme.palette.primary.light,
+                  borderRadius: 1,
+                }
+              : {}),
+            padding: 1,
             fontSize: '1.2rem',
-            textDecoration: isActive ? 'underline' : 'none',
           }}
         >
           {label}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -16,14 +16,20 @@
   },
   "pages": {
     "dashboard": "Camera dashboard",
-    "alerts": "Alerts",
-    "history": "History"
+    "alerts": "Live alerts",
+    "history": "History alerts"
   },
   "topbar": {
     "menuLabel": "Menu"
   },
   "common": {
     "lastUpdate": "Last update:"
+  },
+  "errorPages": {
+    "title": "Ooops !",
+    "notFoundMessage": "We couldn't find the page you're looking for...",
+    "errorMessage": "Something went wrong on our side. Please try again later.",
+    "button": "Go to homepage"
   },
   "dashboard": {
     "noCameraMessage": "No camera is associated with your account. Please contact the administrator",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -16,14 +16,20 @@
   },
   "pages": {
     "dashboard": "Panel de cámaras",
-    "alerts": "Alertas",
-    "history": "Histórico"
+    "alerts": "Alertas en vivo",
+    "history": "Histórico de alertas"
   },
   "topbar": {
     "menuLabel": "Menú"
   },
   "common": {
     "lastUpdate": "Última actualización:"
+  },
+  "errorPages": {
+    "title": "¡Ups!",
+    "notFoundMessage": "No hemos podido encontrar la página que buscas...",
+    "errorMessage": "Se ha producido un error. Vuelva a intentarlo más tarde.",
+    "button": "Ir a la página de inicio"
   },
   "dashboard": {
     "noCameraMessage": "No hay ninguna cámara asociada a su organización. Póngase en contacto con el administrador",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -16,14 +16,20 @@
   },
   "pages": {
     "dashboard": "Caméras",
-    "alerts": "Alertes",
-    "history": "Historique"
+    "alerts": "Alertes en cours",
+    "history": "Historique des alertes"
   },
   "topbar": {
     "menuLabel": "Menu"
   },
   "common": {
     "lastUpdate": "Dernière mise à jour :"
+  },
+  "errorPages": {
+    "title": "Oups !",
+    "notFoundMessage": "Nous n'avons pas trouvé la page que vous recherchez...",
+    "errorMessage": "Une erreur inattendue est survenue. Veuillez réessayer plus tard.",
+    "button": "Revenir à la page principale"
   },
   "dashboard": {
     "noCameraMessage": "Aucune caméra n'est associée avec votre organisation. Veuillez contacter l'administateur",

--- a/src/pages/ErrorPage.tsx
+++ b/src/pages/ErrorPage.tsx
@@ -1,0 +1,44 @@
+import { Button, Stack, Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+
+import { DEFAULT_ROUTE } from '@/App';
+import logo from '@/assets/small-logo.png';
+import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
+
+interface ErrorPageProps {
+  is404?: boolean;
+}
+
+export const ErrorPage = ({ is404 = false }: ErrorPageProps) => {
+  const { t } = useTranslationPrefix('errorPages');
+  const navigate = useNavigate();
+  return (
+    <Stack
+      direction="row"
+      p={4}
+      justifyContent="center"
+      alignItems="center"
+      spacing={4}
+    >
+      <Stack>
+        <img height="300px" src={logo} alt="Logo" />
+      </Stack>
+      <Stack spacing={2}>
+        <Typography fontSize="2rem" fontWeight="bold">
+          {t('title')}
+        </Typography>
+        <Typography variant="body2">
+          {t(is404 ? 'notFoundMessage' : 'errorMessage')}
+        </Typography>
+        <div style={{ alignSelf: 'center' }}>
+          <Button
+            variant="contained"
+            onClick={() => void navigate(DEFAULT_ROUTE)}
+          >
+            {t('button')}
+          </Button>
+        </div>
+      </Stack>
+    </Stack>
+  );
+};


### PR DESCRIPTION
**What is done here**
In topbar : 
- Change style of selected page (with background color instead of underlined)
- Change label of pages
<img width="1918" height="122" alt="image" src="https://github.com/user-attachments/assets/9f3c9c42-88b7-42ad-acc6-6fe188827e6a" />
<img width="1918" height="123" alt="image" src="https://github.com/user-attachments/assets/df801524-6975-4534-8d9d-e0e4646206f0" />
<img width="1918" height="120" alt="image" src="https://github.com/user-attachments/assets/aec0de23-2f02-4138-83dd-b379add94899" />


In the app:
- add a 404 page for unknown path
- add a error page for unexpected exceptions (error boundaries)
<img width="1918" height="857" alt="Capture d’écran 2025-09-14 195808" src="https://github.com/user-attachments/assets/51e296ce-f369-4aae-834f-e61ce58247a2" />


**What should be done in another PR**
- Change the icon in the error page (example : an illustration of a forest with a 404 card,...)