### PR TITLE
Feat: delete iframe and call whep directly

### DIFF
--- a/src/components/Live/LiveContent/LiveStreamPanel.tsx
+++ b/src/components/Live/LiveContent/LiveStreamPanel.tsx
@@ -1,8 +1,8 @@
-import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { useEffect, useRef, useState } from 'react';
 
+import { Loader } from '@/components/Common/Loader';
 import { STATUS_ERROR, STATUS_LOADING, STATUS_SUCCESS } from '@/services/axios';
 import type { CameraFullInfosType } from '@/utils/camera';
 import { calculateHasRotation, SPEEDS } from '@/utils/live';
@@ -19,8 +19,6 @@ interface LiveStreamPanelProps {
   stopStreamingVideo: (ip: string, hasRotation: boolean) => void;
   statusStreamingVideo: string;
 }
-
-const DEFAULT_HEIGHT_VIDEO = 450;
 
 export const LiveStreamPanel = ({
   urlStreaming,
@@ -67,11 +65,9 @@ export const LiveStreamPanel = ({
       {(statusStreamingVideo === STATUS_LOADING ||
         (statusStreamingVideo === STATUS_SUCCESS &&
           !mediaMtx.isInitialized)) && (
-        <Skeleton
-          variant="rectangular"
-          width="100%"
-          height={DEFAULT_HEIGHT_VIDEO}
-        />
+        <div>
+          <Loader />
+        </div>
       )}
       {statusStreamingVideo === STATUS_SUCCESS && (
         <>

--- a/src/components/Live/LiveContent/LiveStreamPanel.tsx
+++ b/src/components/Live/LiveContent/LiveStreamPanel.tsx
@@ -59,7 +59,10 @@ export const LiveStreamPanel = ({
         <Typography variant="body2">{t('errorNoStreaming')}</Typography>
       )}
       {mediaMtx.isInitialized && mediaMtx.hasError && (
-        <Typography variant="body2">{t('errorMediaMtx')}</Typography>
+        <Typography variant="body2">{t('errorTmpMediaMtx')}</Typography>
+      )}
+      {mediaMtx.isStopped && (
+        <Typography variant="body2">{t('errorFinalMediaMtx')}</Typography>
       )}
       {(statusStreamingVideo === STATUS_LOADING ||
         (statusStreamingVideo === STATUS_SUCCESS &&

--- a/src/components/Live/LiveContent/LiveStreamPanel.tsx
+++ b/src/components/Live/LiveContent/LiveStreamPanel.tsx
@@ -8,7 +8,7 @@ import type { CameraFullInfosType } from '@/utils/camera';
 import { calculateHasRotation, SPEEDS } from '@/utils/live';
 import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
 
-import { useMediaMtx } from '../hooks/useMediaMtx';
+import { StateStreaming, useMediaMtx } from '../hooks/useMediaMtx';
 import { FloatingActions } from './StreamActions/FloatingActions';
 import { QuickActions } from './StreamActions/QuickActions';
 
@@ -56,18 +56,22 @@ export const LiveStreamPanel = ({
       {statusStreamingVideo === STATUS_ERROR && (
         <Typography variant="body2">{t('errorNoStreaming')}</Typography>
       )}
-      {mediaMtx.isInitialized && mediaMtx.hasError && (
-        <Typography variant="body2">{t('errorTmpMediaMtx')}</Typography>
+      {mediaMtx.state === StateStreaming.WITH_ERROR && (
+        <Stack spacing={4}>
+          <Loader />
+          <Typography variant="body2">{t('errorTmpMediaMtx')}</Typography>
+        </Stack>
       )}
-      {mediaMtx.isStopped && (
+      {mediaMtx.state === StateStreaming.STOPPED && (
         <Typography variant="body2">{t('errorFinalMediaMtx')}</Typography>
       )}
       {(statusStreamingVideo === STATUS_LOADING ||
         (statusStreamingVideo === STATUS_SUCCESS &&
-          !mediaMtx.isInitialized)) && (
-        <div>
+          mediaMtx.state === StateStreaming.IN_CREATION)) && (
+        <Stack spacing={4}>
           <Loader />
-        </div>
+          <Typography variant="body2">{t('loadingVideo')}</Typography>
+        </Stack>
       )}
       {statusStreamingVideo === STATUS_SUCCESS && (
         <>
@@ -80,10 +84,13 @@ export const LiveStreamPanel = ({
                 background: '#1e1e1e',
                 width: '100%',
                 height: '100%',
-                display: mediaMtx.isInitialized ? 'inline' : 'none',
+                display:
+                  mediaMtx.state === StateStreaming.IS_STREAMING
+                    ? 'inline'
+                    : 'none',
               }}
             />
-            {mediaMtx.isInitialized && (
+            {mediaMtx.state === StateStreaming.IS_STREAMING && (
               <FloatingActions
                 cameraIp={ip}
                 cameraType={camera?.type}
@@ -91,7 +98,7 @@ export const LiveStreamPanel = ({
               />
             )}
           </div>
-          {hasRotation && mediaMtx.isInitialized && (
+          {hasRotation && mediaMtx.state === StateStreaming.IS_STREAMING && (
             <QuickActions
               cameraIp={ip}
               poses={camera.poses ?? []}

--- a/src/components/Live/LiveContent/LiveStreamPanel.tsx
+++ b/src/components/Live/LiveContent/LiveStreamPanel.tsx
@@ -87,13 +87,15 @@ export const LiveStreamPanel = ({
                 display: mediaMtx.isInitialized ? 'inline' : 'none',
               }}
             />
-            <FloatingActions
-              cameraIp={ip}
-              cameraType={camera?.type}
-              speed={SPEEDS[speedIndex].speed}
-            />
+            {mediaMtx.isInitialized && (
+              <FloatingActions
+                cameraIp={ip}
+                cameraType={camera?.type}
+                speed={SPEEDS[speedIndex].speed}
+              />
+            )}
           </div>
-          {hasRotation && (
+          {hasRotation && mediaMtx.isInitialized && (
             <QuickActions
               cameraIp={ip}
               poses={camera.poses ?? []}

--- a/src/components/Live/hooks/reader.js
+++ b/src/components/Live/hooks/reader.js
@@ -65,7 +65,7 @@ export class MediaMTXWebRTCReader {
   }
 
   static #supportsNonAdvertisedCodec(codec, fmtp) {
-    console.log("#supportsNonAdvertisedCodec");
+    console.log('#supportsNonAdvertisedCodec');
     return new Promise((resolve) => {
       const pc = new RTCPeerConnection({ iceServers: [] });
       const mediaType = 'audio';

--- a/src/components/Live/hooks/reader.js
+++ b/src/components/Live/hooks/reader.js
@@ -12,11 +12,17 @@
  */
 
 /**
+ * @callback OnFailLoading
+ * @param {} evt - failed reading event.
+ */
+
+/**
  * @typedef Conf
  * @type {object}
  * @property {string} url - absolute URL of the WHEP endpoint.
  * @property {OnError} onError - called when there's an error.
  * @property {OnTrack} onTrack - called when there's a track available.
+ * @property {OnFailLoading} onFailLoading - called when there's no more call to WHEP endpoint.
  */
 
 const RETRY_PAUSE_IN_MS = 4000;
@@ -418,7 +424,7 @@ export class MediaMTXWebRTCReader {
 
       this.queuedCandidates = [];
 
-      if (this.restartNb < RETRY_NB_MAX && this.restartTimeout == null) {
+      if (this.restartNb < RETRY_NB_MAX) {
         this.state = 'restarting';
         this.restartTimeout = setTimeout(() => {
           this.restartNb = this.restartNb + 1;
@@ -426,6 +432,8 @@ export class MediaMTXWebRTCReader {
           this.state = 'running';
           this.#start();
         }, RETRY_PAUSE_IN_MS);
+      } else {
+        this.onFailLoading();
       }
 
       if (this.conf.onError !== undefined) {

--- a/src/components/Live/hooks/reader.js
+++ b/src/components/Live/hooks/reader.js
@@ -13,7 +13,7 @@
 
 /**
  * @callback OnFailLoading
- * @param {} evt - failed reading event.
+ * @param {} - failed reading event.
  */
 
 /**

--- a/src/components/Live/hooks/reader.js
+++ b/src/components/Live/hooks/reader.js
@@ -25,8 +25,8 @@
  * @property {OnFailLoading} onFailLoading - called when there's no more call to WHEP endpoint.
  */
 
-const RETRY_PAUSE_IN_MS = 4000;
-const RETRY_NB_MAX = 200;
+const RETRY_PAUSE_IN_MS = 2000;
+const RETRY_NB_MAX = 50;
 
 /** WebRTC/WHEP reader. */
 export class MediaMTXWebRTCReader {
@@ -36,7 +36,6 @@ export class MediaMTXWebRTCReader {
    */
   constructor(conf) {
     this.conf = conf;
-    this.state = 'getting_codecs';
     this.restartTimeout = null;
     this.restartNb = 0;
     this.pc = null;
@@ -46,6 +45,7 @@ export class MediaMTXWebRTCReader {
   }
 
   start() {
+    this.state = 'getting_codecs';
     this.#getNonAdvertisedCodecs();
   }
 
@@ -65,6 +65,7 @@ export class MediaMTXWebRTCReader {
   }
 
   static #supportsNonAdvertisedCodec(codec, fmtp) {
+    console.log("#supportsNonAdvertisedCodec");
     return new Promise((resolve) => {
       const pc = new RTCPeerConnection({ iceServers: [] });
       const mediaType = 'audio';

--- a/src/components/Live/hooks/reader.js
+++ b/src/components/Live/hooks/reader.js
@@ -1,0 +1,640 @@
+// Source : https://github.com/bluenviron/mediamtx/blob/v1.15.0/internal/servers/webrtc/reader.js
+// Update : Add restartNb and add limit RETRY_NB_MAX
+// Update : separate constructor and start method
+/**
+ * @callback OnError
+ * @param {string} err - error.
+ */
+
+/**
+ * @callback OnTrack
+ * @param {RTCTrackEvent} evt - track event.
+ */
+
+/**
+ * @typedef Conf
+ * @type {object}
+ * @property {string} url - absolute URL of the WHEP endpoint.
+ * @property {OnError} onError - called when there's an error.
+ * @property {OnTrack} onTrack - called when there's a track available.
+ */
+
+const RETRY_PAUSE_IN_MS = 4000;
+const RETRY_NB_MAX = 200;
+
+/** WebRTC/WHEP reader. */
+export class MediaMTXWebRTCReader {
+  /**
+   * Create a MediaMTXWebRTCReader.
+   * @param {Conf} conf - configuration.
+   */
+  constructor(conf) {
+    this.conf = conf;
+    this.state = 'getting_codecs';
+    this.restartTimeout = null;
+    this.restartNb = 0;
+    this.pc = null;
+    this.offerData = null;
+    this.sessionUrl = null;
+    this.queuedCandidates = [];
+  }
+
+  start() {
+    this.#getNonAdvertisedCodecs();
+  }
+
+  /**
+   * Close the reader and all its resources.
+   */
+  close() {
+    this.state = 'closed';
+
+    if (this.pc !== null) {
+      this.pc.close();
+    }
+
+    if (this.restartTimeout !== null) {
+      clearTimeout(this.restartTimeout);
+    }
+  }
+
+  static #supportsNonAdvertisedCodec(codec, fmtp) {
+    return new Promise((resolve) => {
+      const pc = new RTCPeerConnection({ iceServers: [] });
+      const mediaType = 'audio';
+      let payloadType = '';
+
+      pc.addTransceiver(mediaType, { direction: 'recvonly' });
+      pc.createOffer()
+        .then((offer) => {
+          if (offer.sdp === undefined) {
+            throw new Error('SDP not present');
+          }
+          if (offer.sdp.includes(` ${codec}`)) {
+            // codec is advertised, there's no need to add it manually
+            throw new Error('already present');
+          }
+
+          const sections = offer.sdp.split(`m=${mediaType}`);
+
+          const payloadTypes = sections
+            .slice(1)
+            .map((s) => s.split('\r\n')[0].split(' ').slice(3))
+            .reduce((prev, cur) => [...prev, ...cur], []);
+          payloadType = this.#reservePayloadType(payloadTypes);
+
+          const lines = sections[1].split('\r\n');
+          lines[0] += ` ${payloadType}`;
+          lines.splice(lines.length - 1, 0, `a=rtpmap:${payloadType} ${codec}`);
+          if (fmtp !== undefined) {
+            lines.splice(lines.length - 1, 0, `a=fmtp:${payloadType} ${fmtp}`);
+          }
+          sections[1] = lines.join('\r\n');
+          offer.sdp = sections.join(`m=${mediaType}`);
+          return pc.setLocalDescription(offer);
+        })
+        .then(() =>
+          pc.setRemoteDescription(
+            new RTCSessionDescription({
+              type: 'answer',
+              sdp:
+                'v=0\r\n' +
+                'o=- 6539324223450680508 0 IN IP4 0.0.0.0\r\n' +
+                's=-\r\n' +
+                't=0 0\r\n' +
+                'a=fingerprint:sha-256 0D:9F:78:15:42:B5:4B:E6:E2:94:3E:5B:37:78:E1:4B:54:59:A3:36:3A:E5:05:EB:27:EE:8F:D2:2D:41:29:25\r\n' +
+                `m=${mediaType} 9 UDP/TLS/RTP/SAVPF ${payloadType}\r\n` +
+                'c=IN IP4 0.0.0.0\r\n' +
+                'a=ice-pwd:7c3bf4770007e7432ee4ea4d697db675\r\n' +
+                'a=ice-ufrag:29e036dc\r\n' +
+                'a=sendonly\r\n' +
+                'a=rtcp-mux\r\n' +
+                `a=rtpmap:${payloadType} ${codec}\r\n` +
+                (fmtp !== undefined ? `a=fmtp:${payloadType} ${fmtp}\r\n` : ''),
+            })
+          )
+        )
+        .then(() => {
+          resolve(true);
+        })
+        .catch(() => {
+          resolve(false);
+        })
+        .finally(() => {
+          pc.close();
+        });
+    });
+  }
+
+  static #unquoteCredential(v) {
+    return JSON.parse(`"${v}"`);
+  }
+
+  static #linkToIceServers(links) {
+    return links !== null
+      ? links.split(', ').map((link) => {
+          const m = link.match(
+            /^<(.+?)>; rel="ice-server"(; username="(.*?)"; credential="(.*?)"; credential-type="password")?/i
+          );
+          const ret = {
+            urls: [m[1]],
+          };
+
+          if (m[3] !== undefined) {
+            ret.username = this.#unquoteCredential(m[3]);
+            ret.credential = this.#unquoteCredential(m[4]);
+            ret.credentialType = 'password';
+          }
+
+          return ret;
+        })
+      : [];
+  }
+
+  static #parseOffer(sdp) {
+    const ret = {
+      iceUfrag: '',
+      icePwd: '',
+      medias: [],
+    };
+
+    for (const line of sdp.split('\r\n')) {
+      if (line.startsWith('m=')) {
+        ret.medias.push(line.slice('m='.length));
+      } else if (ret.iceUfrag === '' && line.startsWith('a=ice-ufrag:')) {
+        ret.iceUfrag = line.slice('a=ice-ufrag:'.length);
+      } else if (ret.icePwd === '' && line.startsWith('a=ice-pwd:')) {
+        ret.icePwd = line.slice('a=ice-pwd:'.length);
+      }
+    }
+
+    return ret;
+  }
+
+  static #reservePayloadType(payloadTypes) {
+    // everything is valid between 30 and 127, except for interval between 64 and 95
+    // https://chromium.googlesource.com/external/webrtc/+/refs/heads/master/call/payload_type.h#29
+    for (let i = 30; i <= 127; i++) {
+      if ((i <= 63 || i >= 96) && !payloadTypes.includes(i.toString())) {
+        const pl = i.toString();
+        payloadTypes.push(pl);
+        return pl;
+      }
+    }
+    throw Error('unable to find a free payload type');
+  }
+
+  static #enableStereoPcmau(payloadTypes, section) {
+    const lines = section.split('\r\n');
+
+    let payloadType = this.#reservePayloadType(payloadTypes);
+    lines[0] += ` ${payloadType}`;
+    lines.splice(lines.length - 1, 0, `a=rtpmap:${payloadType} PCMU/8000/2`);
+    lines.splice(lines.length - 1, 0, `a=rtcp-fb:${payloadType} transport-cc`);
+
+    payloadType = this.#reservePayloadType(payloadTypes);
+    lines[0] += ` ${payloadType}`;
+    lines.splice(lines.length - 1, 0, `a=rtpmap:${payloadType} PCMA/8000/2`);
+    lines.splice(lines.length - 1, 0, `a=rtcp-fb:${payloadType} transport-cc`);
+
+    return lines.join('\r\n');
+  }
+
+  static #enableMultichannelOpus(payloadTypes, section) {
+    const lines = section.split('\r\n');
+
+    let payloadType = this.#reservePayloadType(payloadTypes);
+    lines[0] += ` ${payloadType}`;
+    lines.splice(
+      lines.length - 1,
+      0,
+      `a=rtpmap:${payloadType} multiopus/48000/3`
+    );
+    lines.splice(
+      lines.length - 1,
+      0,
+      `a=fmtp:${payloadType} channel_mapping=0,2,1;num_streams=2;coupled_streams=1`
+    );
+    lines.splice(lines.length - 1, 0, `a=rtcp-fb:${payloadType} transport-cc`);
+
+    payloadType = this.#reservePayloadType(payloadTypes);
+    lines[0] += ` ${payloadType}`;
+    lines.splice(
+      lines.length - 1,
+      0,
+      `a=rtpmap:${payloadType} multiopus/48000/4`
+    );
+    lines.splice(
+      lines.length - 1,
+      0,
+      `a=fmtp:${payloadType} channel_mapping=0,1,2,3;num_streams=2;coupled_streams=2`
+    );
+    lines.splice(lines.length - 1, 0, `a=rtcp-fb:${payloadType} transport-cc`);
+
+    payloadType = this.#reservePayloadType(payloadTypes);
+    lines[0] += ` ${payloadType}`;
+    lines.splice(
+      lines.length - 1,
+      0,
+      `a=rtpmap:${payloadType} multiopus/48000/5`
+    );
+    lines.splice(
+      lines.length - 1,
+      0,
+      `a=fmtp:${payloadType} channel_mapping=0,4,1,2,3;num_streams=3;coupled_streams=2`
+    );
+    lines.splice(lines.length - 1, 0, `a=rtcp-fb:${payloadType} transport-cc`);
+
+    payloadType = this.#reservePayloadType(payloadTypes);
+    lines[0] += ` ${payloadType}`;
+    lines.splice(
+      lines.length - 1,
+      0,
+      `a=rtpmap:${payloadType} multiopus/48000/6`
+    );
+    lines.splice(
+      lines.length - 1,
+      0,
+      `a=fmtp:${payloadType} channel_mapping=0,4,1,2,3,5;num_streams=4;coupled_streams=2`
+    );
+    lines.splice(lines.length - 1, 0, `a=rtcp-fb:${payloadType} transport-cc`);
+
+    payloadType = this.#reservePayloadType(payloadTypes);
+    lines[0] += ` ${payloadType}`;
+    lines.splice(
+      lines.length - 1,
+      0,
+      `a=rtpmap:${payloadType} multiopus/48000/7`
+    );
+    lines.splice(
+      lines.length - 1,
+      0,
+      `a=fmtp:${payloadType} channel_mapping=0,4,1,2,3,5,6;num_streams=4;coupled_streams=4`
+    );
+    lines.splice(lines.length - 1, 0, `a=rtcp-fb:${payloadType} transport-cc`);
+
+    payloadType = this.#reservePayloadType(payloadTypes);
+    lines[0] += ` ${payloadType}`;
+    lines.splice(
+      lines.length - 1,
+      0,
+      `a=rtpmap:${payloadType} multiopus/48000/8`
+    );
+    lines.splice(
+      lines.length - 1,
+      0,
+      `a=fmtp:${payloadType} channel_mapping=0,6,1,4,5,2,3,7;num_streams=5;coupled_streams=4`
+    );
+    lines.splice(lines.length - 1, 0, `a=rtcp-fb:${payloadType} transport-cc`);
+
+    return lines.join('\r\n');
+  }
+
+  static #enableL16(payloadTypes, section) {
+    const lines = section.split('\r\n');
+
+    let payloadType = this.#reservePayloadType(payloadTypes);
+    lines[0] += ` ${payloadType}`;
+    lines.splice(lines.length - 1, 0, `a=rtpmap:${payloadType} L16/8000/2`);
+    lines.splice(lines.length - 1, 0, `a=rtcp-fb:${payloadType} transport-cc`);
+
+    payloadType = this.#reservePayloadType(payloadTypes);
+    lines[0] += ` ${payloadType}`;
+    lines.splice(lines.length - 1, 0, `a=rtpmap:${payloadType} L16/16000/2`);
+    lines.splice(lines.length - 1, 0, `a=rtcp-fb:${payloadType} transport-cc`);
+
+    payloadType = this.#reservePayloadType(payloadTypes);
+    lines[0] += ` ${payloadType}`;
+    lines.splice(lines.length - 1, 0, `a=rtpmap:${payloadType} L16/48000/2`);
+    lines.splice(lines.length - 1, 0, `a=rtcp-fb:${payloadType} transport-cc`);
+
+    return lines.join('\r\n');
+  }
+
+  static #enableStereoOpus(section) {
+    let opusPayloadFormat = '';
+    const lines = section.split('\r\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      if (
+        lines[i].startsWith('a=rtpmap:') &&
+        lines[i].toLowerCase().includes('opus/')
+      ) {
+        opusPayloadFormat = lines[i].slice('a=rtpmap:'.length).split(' ')[0];
+        break;
+      }
+    }
+
+    if (opusPayloadFormat === '') {
+      return section;
+    }
+
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].startsWith(`a=fmtp:${opusPayloadFormat} `)) {
+        if (!lines[i].includes('stereo')) {
+          lines[i] += ';stereo=1';
+        }
+        if (!lines[i].includes('sprop-stereo')) {
+          lines[i] += ';sprop-stereo=1';
+        }
+      }
+    }
+
+    return lines.join('\r\n');
+  }
+
+  static #editOffer(sdp, nonAdvertisedCodecs) {
+    const sections = sdp.split('m=');
+
+    const payloadTypes = sections
+      .slice(1)
+      .map((s) => s.split('\r\n')[0].split(' ').slice(3))
+      .reduce((prev, cur) => [...prev, ...cur], []);
+
+    for (let i = 1; i < sections.length; i++) {
+      if (sections[i].startsWith('audio')) {
+        sections[i] = this.#enableStereoOpus(sections[i]);
+
+        if (nonAdvertisedCodecs.includes('pcma/8000/2')) {
+          sections[i] = this.#enableStereoPcmau(payloadTypes, sections[i]);
+        }
+        if (nonAdvertisedCodecs.includes('multiopus/48000/6')) {
+          sections[i] = this.#enableMultichannelOpus(payloadTypes, sections[i]);
+        }
+        if (nonAdvertisedCodecs.includes('L16/48000/2')) {
+          sections[i] = this.#enableL16(payloadTypes, sections[i]);
+        }
+
+        break;
+      }
+    }
+
+    return sections.join('m=');
+  }
+
+  static #generateSdpFragment(od, candidates) {
+    const candidatesByMedia = {};
+    for (const candidate of candidates) {
+      const mid = candidate.sdpMLineIndex;
+      if (candidatesByMedia[mid] === undefined) {
+        candidatesByMedia[mid] = [];
+      }
+      candidatesByMedia[mid].push(candidate);
+    }
+
+    let frag = `a=ice-ufrag:${od.iceUfrag}\r\n` + `a=ice-pwd:${od.icePwd}\r\n`;
+
+    let mid = 0;
+
+    for (const media of od.medias) {
+      if (candidatesByMedia[mid] !== undefined) {
+        frag += `m=${media}\r\n` + `a=mid:${mid}\r\n`;
+
+        for (const candidate of candidatesByMedia[mid]) {
+          frag += `a=${candidate.candidate}\r\n`;
+        }
+      }
+      mid++;
+    }
+
+    return frag;
+  }
+
+  #handleError(err) {
+    if (this.state === 'running') {
+      if (this.pc !== null) {
+        this.pc.close();
+        this.pc = null;
+      }
+
+      this.offerData = null;
+
+      if (this.sessionUrl !== null) {
+        fetch(this.sessionUrl, {
+          method: 'DELETE',
+        });
+        this.sessionUrl = null;
+      }
+
+      this.queuedCandidates = [];
+
+      if (this.restartNb < RETRY_NB_MAX && this.restartTimeout == null) {
+        this.state = 'restarting';
+        this.restartTimeout = setTimeout(() => {
+          this.restartNb = this.restartNb + 1;
+          this.restartTimeout = null;
+          this.state = 'running';
+          this.#start();
+        }, RETRY_PAUSE_IN_MS);
+      }
+
+      if (this.conf.onError !== undefined) {
+        this.conf.onError(`${err}, retrying in some seconds`);
+      }
+    } else if (this.state === 'getting_codecs') {
+      this.state = 'failed';
+
+      if (this.conf.onError !== undefined) {
+        this.conf.onError(err);
+      }
+    }
+  }
+
+  #getNonAdvertisedCodecs() {
+    Promise.all(
+      [
+        ['pcma/8000/2'],
+        [
+          'multiopus/48000/6',
+          'channel_mapping=0,4,1,2,3,5;num_streams=4;coupled_streams=2',
+        ],
+        ['L16/48000/2'],
+      ].map((c) =>
+        MediaMTXWebRTCReader.#supportsNonAdvertisedCodec(c[0], c[1]).then(
+          (r) => (r ? c[0] : false)
+        )
+      )
+    )
+      .then((c) => c.filter((e) => e !== false))
+      .then((codecs) => {
+        if (this.state !== 'getting_codecs') {
+          throw new Error('closed');
+        }
+
+        this.nonAdvertisedCodecs = codecs;
+        this.state = 'running';
+        this.#start();
+      })
+      .catch((err) => {
+        this.#handleError(err);
+      });
+  }
+
+  #start() {
+    this.#requestICEServers()
+      .then((iceServers) => this.#setupPeerConnection(iceServers))
+      .then((offer) => this.#sendOffer(offer))
+      .then((answer) => this.#setAnswer(answer))
+      .catch((err) => {
+        this.#handleError(err.toString());
+      });
+  }
+
+  #requestICEServers() {
+    return fetch(this.conf.url, {
+      method: 'OPTIONS',
+    }).then((res) =>
+      MediaMTXWebRTCReader.#linkToIceServers(res.headers.get('Link'))
+    );
+  }
+
+  #setupPeerConnection(iceServers) {
+    if (this.state !== 'running') {
+      throw new Error('closed');
+    }
+
+    this.pc = new RTCPeerConnection({
+      iceServers,
+      // https://webrtc.org/getting-started/unified-plan-transition-guide
+      sdpSemantics: 'unified-plan',
+    });
+
+    const direction = 'recvonly';
+    this.pc.addTransceiver('video', { direction });
+    this.pc.addTransceiver('audio', { direction });
+
+    this.pc.onicecandidate = (evt) => this.#onLocalCandidate(evt);
+    this.pc.onconnectionstatechange = () => this.#onConnectionState();
+    this.pc.ontrack = (evt) => this.#onTrack(evt);
+
+    return this.pc.createOffer().then((offer) => {
+      offer.sdp = MediaMTXWebRTCReader.#editOffer(
+        offer.sdp,
+        this.nonAdvertisedCodecs
+      );
+      this.offerData = MediaMTXWebRTCReader.#parseOffer(offer.sdp);
+
+      return this.pc.setLocalDescription(offer).then(() => offer.sdp);
+    });
+  }
+
+  #sendOffer(offer) {
+    if (this.state !== 'running') {
+      throw new Error('closed');
+    }
+
+    return fetch(this.conf.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/sdp' },
+      body: offer,
+    }).then((res) => {
+      switch (res.status) {
+        case 201:
+          break;
+        case 404:
+          throw new Error('stream not found');
+        case 400:
+          return res.json().then((e) => {
+            throw new Error(e.error);
+          });
+        default:
+          throw new Error(`bad status code ${res.status}`);
+      }
+
+      this.sessionUrl = new URL(
+        res.headers.get('location'),
+        this.conf.url
+      ).toString();
+
+      return res.text();
+    });
+  }
+
+  #setAnswer(answer) {
+    if (this.state !== 'running') {
+      throw new Error('closed');
+    }
+
+    return this.pc
+      .setRemoteDescription(
+        new RTCSessionDescription({
+          type: 'answer',
+          sdp: answer,
+        })
+      )
+      .then(() => {
+        if (this.state !== 'running') {
+          return;
+        }
+
+        if (this.queuedCandidates.length !== 0) {
+          this.#sendLocalCandidates(this.queuedCandidates);
+          this.queuedCandidates = [];
+        }
+      });
+  }
+
+  #onLocalCandidate(evt) {
+    if (this.state !== 'running') {
+      return;
+    }
+
+    if (evt.candidate !== null) {
+      if (this.sessionUrl === null) {
+        this.queuedCandidates.push(evt.candidate);
+      } else {
+        this.#sendLocalCandidates([evt.candidate]);
+      }
+    }
+  }
+
+  #sendLocalCandidates(candidates) {
+    fetch(this.sessionUrl, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/trickle-ice-sdpfrag',
+        'If-Match': '*',
+      },
+      body: MediaMTXWebRTCReader.#generateSdpFragment(
+        this.offerData,
+        candidates
+      ),
+    })
+      .then((res) => {
+        switch (res.status) {
+          case 204:
+            break;
+          case 404:
+            throw new Error('stream not found');
+          default:
+            throw new Error(`bad status code ${res.status}`);
+        }
+      })
+      .catch((err) => {
+        this.#handleError(err.toString());
+      });
+  }
+
+  #onConnectionState() {
+    if (this.state !== 'running') {
+      return;
+    }
+
+    // "closed" can arrive before "failed" and without
+    // the close() method being called at all.
+    // It happens when the other peer sends a termination
+    // message like a DTLS CloseNotify.
+    if (
+      this.pc.connectionState === 'failed' ||
+      this.pc.connectionState === 'closed'
+    ) {
+      this.#handleError('peer connection closed');
+    }
+  }
+
+  #onTrack(evt) {
+    if (this.conf.onTrack !== undefined) {
+      this.conf.onTrack(evt);
+    }
+  }
+}

--- a/src/components/Live/hooks/useMediaMtx.tsx
+++ b/src/components/Live/hooks/useMediaMtx.tsx
@@ -8,15 +8,19 @@ interface StreamVideoProps {
   ip: string;
 }
 
+export const StateStreaming = {
+  IN_CREATION: 0, // StartStreaming command launched, waiting for the data to arrive to the broadcast url
+  IS_STREAMING: 1, // The reader is broadcasting data
+  WITH_ERROR: 2, // Temporary failure in broadcasting data
+  STOPPED: 3, // The reader has failed and will not try again de connect the broadcast url
+};
+
 export const useMediaMtx = ({
   urlStreaming,
   refVideo,
   ip,
 }: StreamVideoProps) => {
-  // This boolean prevents from displaying error as long as the stream has no started yet
-  const [isInitialized, setIsInitialized] = useState(false);
-  const [isStopped, setIsStopped] = useState(false);
-  const [hasError, setHasError] = useState(false);
+  const [state, setState] = useState<number>(StateStreaming.IN_CREATION);
 
   const reader = useMemo(() => {
     if (urlStreaming) {
@@ -24,18 +28,24 @@ export const useMediaMtx = ({
         url: urlStreaming,
         onError: (err: string) => {
           console.log(err);
-          setHasError(true);
+          setState((oldValue) =>
+            // Set to error state only if the video is initialized
+            oldValue === StateStreaming.IS_STREAMING
+              ? StateStreaming.WITH_ERROR
+              : oldValue
+          );
         },
         onTrack: (evt: RTCTrackEvent) => {
           // Signal from streaming is etablished
-          setIsInitialized(true);
-          setHasError(false);
+
+          setState(StateStreaming.IS_STREAMING);
           if (refVideo.current) {
             refVideo.current.srcObject = evt.streams[0];
           }
         },
         onFailLoading: () => {
-          setIsStopped(true);
+          console.error('failed loading stream');
+          setState(StateStreaming.STOPPED);
         },
       });
     } else {
@@ -44,26 +54,18 @@ export const useMediaMtx = ({
   }, [refVideo, urlStreaming]);
 
   useEffect(() => {
-    // Clean up video state
-    return () => {
-      if (ip) {
-        setIsInitialized(false);
-        setHasError(false);
-      }
-    };
-  }, [ip]);
-
-  useEffect(() => {
     // Clean up reader
-    if (reader) {
+    if (reader && ip) {
+      setState(StateStreaming.IN_CREATION);
       reader.start();
     }
     return () => {
-      if (reader) {
+      if (reader && ip) {
+        setState(StateStreaming.STOPPED);
         reader.close();
       }
     };
-  }, [reader]);
+  }, [reader, ip]);
 
-  return { isInitialized, hasError, isStopped };
+  return { state };
 };

--- a/src/components/Live/hooks/useMediaMtx.tsx
+++ b/src/components/Live/hooks/useMediaMtx.tsx
@@ -1,0 +1,65 @@
+import { type RefObject, useEffect, useMemo, useState } from 'react';
+
+import { MediaMTXWebRTCReader } from './reader';
+
+interface StreamVideoProps {
+  urlStreaming: string;
+  refVideo: RefObject<HTMLVideoElement | null>;
+  ip: string;
+}
+
+export const useMediaMtx = ({
+  urlStreaming,
+  refVideo,
+  ip,
+}: StreamVideoProps) => {
+  // This boolean prevents from displaying error as long as the stream has no started yet
+  const [isInitialized, setIsInitialized] = useState(false);
+  const [hasError, setHasError] = useState(false);
+
+  const reader = useMemo(() => {
+    if (urlStreaming) {
+      return new MediaMTXWebRTCReader({
+        url: urlStreaming,
+        onError: (err: string) => {
+          console.log(err);
+          setHasError(true);
+        },
+        onTrack: (evt: RTCTrackEvent) => {
+          // Signal from streaming is etablished
+          setIsInitialized(true);
+          setHasError(false);
+          if (refVideo.current) {
+            refVideo.current.srcObject = evt.streams[0];
+          }
+        },
+      });
+    } else {
+      return null;
+    }
+  }, [refVideo, urlStreaming]);
+
+  useEffect(() => {
+    // Clean up video state
+    return () => {
+      if (ip) {
+        setIsInitialized(false);
+        setHasError(false);
+      }
+    };
+  }, [ip]);
+
+  useEffect(() => {
+    // Clean up reader
+    if (reader) {
+      reader.start();
+    }
+    return () => {
+      if (reader) {
+        reader.close();
+      }
+    };
+  }, [reader]);
+
+  return { isInitialized, hasError };
+};

--- a/src/components/Live/hooks/useMediaMtx.tsx
+++ b/src/components/Live/hooks/useMediaMtx.tsx
@@ -15,6 +15,7 @@ export const useMediaMtx = ({
 }: StreamVideoProps) => {
   // This boolean prevents from displaying error as long as the stream has no started yet
   const [isInitialized, setIsInitialized] = useState(false);
+  const [isStopped, setIsStopped] = useState(false);
   const [hasError, setHasError] = useState(false);
 
   const reader = useMemo(() => {
@@ -32,6 +33,9 @@ export const useMediaMtx = ({
           if (refVideo.current) {
             refVideo.current.srcObject = evt.streams[0];
           }
+        },
+        onFailLoading: () => {
+          setIsStopped(true);
         },
       });
     } else {
@@ -61,5 +65,5 @@ export const useMediaMtx = ({
     };
   }, [reader]);
 
-  return { isInitialized, hasError };
+  return { isInitialized, hasError, isStopped };
 };

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -108,6 +108,7 @@
     "buttonClose": "Close live stream",
     "alertMessage": "Live stream in progress: detection inactive since {{timeSpent}}",
     "errorNoStreaming": "Something went wrong on our side. Please try again later.",
+    "errorMediaMtx": "Video stream interrupted",
     "tooltipSpeed": "Camera movement speed",
     "tooltipAzimuths": "Pre-recorded camera azimuths"
   }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -108,7 +108,8 @@
     "buttonClose": "Close live stream",
     "alertMessage": "Live stream in progress: detection inactive since {{timeSpent}}",
     "errorNoStreaming": "Something went wrong on our side. Please try again later.",
-    "errorMediaMtx": "Video stream interrupted",
+    "errorTmpMediaMtx": "Video stream interrupted. Please wait.",
+    "errorFinalMediaMtx": "Video stream has failed. Please try again later.",
     "tooltipSpeed": "Camera movement speed",
     "tooltipAzimuths": "Pre-recorded camera azimuths"
   }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -110,6 +110,7 @@
     "errorNoStreaming": "Something went wrong on our side. Please try again later.",
     "errorTmpMediaMtx": "Video stream interrupted. Please wait.",
     "errorFinalMediaMtx": "Video stream has failed. Please try again later.",
+    "loadingVideo": "Loading video...",
     "tooltipSpeed": "Camera movement speed",
     "tooltipAzimuths": "Pre-recorded camera azimuths"
   }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -108,6 +108,7 @@
     "buttonClose": "Cerrar la transmisión en vivo",
     "alertMessage": "Transmisión en vivo en curso: detección inactiva desde {{timeSpent}}",
     "errorNoStreaming": "Se ha producido un error. Vuelva a intentarlo más tarde.",
+    "errorMediaMtx": "Interrupción del flujo de vídeo",
     "tooltipSpeed": "Velocidad de desplazamiento de la cámara",
     "tooltipAzimuths": "Azimuts pregrabados de la cámara"
   }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -108,7 +108,8 @@
     "buttonClose": "Cerrar la transmisión en vivo",
     "alertMessage": "Transmisión en vivo en curso: detección inactiva desde {{timeSpent}}",
     "errorNoStreaming": "Se ha producido un error. Vuelva a intentarlo más tarde.",
-    "errorMediaMtx": "Interrupción del flujo de vídeo",
+    "errorTmpMediaMtx": "Interrupción del flujo de vídeo. Por favor, espere",
+    "errorFinalMediaMtx": "El streaming de vídeo ha fallado. Inténtalo de nuevo más tarde.",
     "tooltipSpeed": "Velocidad de desplazamiento de la cámara",
     "tooltipAzimuths": "Azimuts pregrabados de la cámara"
   }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -110,6 +110,7 @@
     "errorNoStreaming": "Se ha producido un error. Vuelva a intentarlo más tarde.",
     "errorTmpMediaMtx": "Interrupción del flujo de vídeo. Por favor, espere",
     "errorFinalMediaMtx": "El streaming de vídeo ha fallado. Inténtalo de nuevo más tarde.",
+    "loadingVideo": "Cargando vídeo...",
     "tooltipSpeed": "Velocidad de desplazamiento de la cámara",
     "tooltipAzimuths": "Azimuts pregrabados de la cámara"
   }

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -108,6 +108,7 @@
     "buttonClose": "Fermer la levée de doute",
     "alertMessage": "Levée de doute en cours: détection inactive depuis {{timeSpent}}",
     "errorNoStreaming": "Une erreur inattendue est survenue. Veuillez réessayer plus tard.",
+    "errorMediaMtx": "Flux vidéo interrompu",
     "tooltipSpeed": "Vitesse de déplacément de la caméra",
     "tooltipAzimuths": "Azimuths pré-enregistrés de la caméra"
   }

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -108,7 +108,8 @@
     "buttonClose": "Fermer la levée de doute",
     "alertMessage": "Levée de doute en cours: détection inactive depuis {{timeSpent}}",
     "errorNoStreaming": "Une erreur inattendue est survenue. Veuillez réessayer plus tard.",
-    "errorMediaMtx": "Flux vidéo interrompu",
+    "errorTmpMediaMtx": "Flux vidéo interrompu. Veuillez patienter.",
+    "errorFinalMediaMtx": "Flux vidéo en erreur. Veuillez réessayer plus tard.",
     "tooltipSpeed": "Vitesse de déplacément de la caméra",
     "tooltipAzimuths": "Azimuths pré-enregistrés de la caméra"
   }

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -110,6 +110,7 @@
     "errorNoStreaming": "Une erreur inattendue est survenue. Veuillez réessayer plus tard.",
     "errorTmpMediaMtx": "Flux vidéo interrompu. Veuillez patienter.",
     "errorFinalMediaMtx": "Flux vidéo en erreur. Veuillez réessayer plus tard.",
+    "loadingVideo": "Chargement de la vidéo...",
     "tooltipSpeed": "Vitesse de déplacément de la caméra",
     "tooltipAzimuths": "Azimuths pré-enregistrés de la caméra"
   }

--- a/src/utils/live.ts
+++ b/src/utils/live.ts
@@ -23,7 +23,7 @@ export const SPEEDS: SpeedCameraMove[] = [
 
 export const calculateLiveStreamingUrl = (site: SiteType | null) => {
   return site
-    ? `${import.meta.env.VITE_LIVE_STREAMING_URL}/${site.id}/?controls=false`
+    ? `${import.meta.env.VITE_LIVE_STREAMING_URL}/${site.id}/whep`
     : '';
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowJs": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,


### PR DESCRIPTION
- Remove iframe and replace it with a < video > tag
- Create a hook to deal with the media mtx stream (and add the reader from https://github.com/bluenviron/mediamtx/blob/v1.15.0/internal/servers/webrtc/reader.js)
- Create error message dedicated to the video stream
<img width="1918" height="857" alt="image" src="https://github.com/user-attachments/assets/5fe4406c-e8f1-4df0-9e67-f5fcbcd92923" />

<img width="1918" height="863" alt="image" src="https://github.com/user-attachments/assets/155bcf67-4b1d-4917-ac76-9c0974224a83" />

<img width="1918" height="877" alt="image" src="https://github.com/user-attachments/assets/2e318bc7-8567-45fa-9c0e-9cac022e7ca5" />

