### PR TITLE
fix: change how to display alert info and camera

### DIFF
--- a/src/components/Alerts/AlertDetails/AlertHeader.tsx
+++ b/src/components/Alerts/AlertDetails/AlertHeader.tsx
@@ -39,8 +39,7 @@ export const AlertHeader = ({
 
   const Title = (
     <Typography variant="h1">
-      {t('titleSectionCamera')} {camera?.name ?? t('defaultCameraName')}
-      {camera?.angle_of_view && ` (${camera.angle_of_view.toString()}°)`}
+      {camera?.name ?? t('defaultCameraName')}
     </Typography>
   );
 

--- a/src/components/Alerts/AlertDetails/AlertInfos/AlertInfos.tsx
+++ b/src/components/Alerts/AlertDetails/AlertInfos/AlertInfos.tsx
@@ -5,6 +5,8 @@ import { useTheme } from '@mui/material/styles';
 
 import {
   countUnlabelledSequences,
+  formatAzimuth,
+  formatPosition,
   type SequenceWithCameraInfoType,
 } from '@/utils/alerts';
 import { formatToDateTime } from '@/utils/dates';
@@ -60,11 +62,10 @@ export const AlertInfos = ({
               {formatToDateTime(sequence.startedAt)}
             </AlertInfosSection>
             <AlertInfosSection title={t('subtitleAzimuth')}>
-              {sequence.azimuth ? `${sequence.azimuth.toString()}°` : ''}
+              {formatAzimuth(sequence.coneAzimuth, 1)}
             </AlertInfosSection>
             <AlertInfosSection title={t('subtitleLocalisation')}>
-              {sequence.camera?.lat && `${sequence.camera.lat.toString()}, `}
-              {sequence.camera?.lon.toString()}
+              {formatPosition(sequence.camera?.lat, sequence.camera?.lon)}
             </AlertInfosSection>
           </Grid>
           <Grid container flexGrow={1} minHeight={200}>

--- a/src/components/Alerts/AlertsList/AlertCard.tsx
+++ b/src/components/Alerts/AlertsList/AlertCard.tsx
@@ -9,7 +9,7 @@ import {
 } from '@mui/material';
 import Card from '@mui/material/Card';
 
-import type { AlertType } from '@//utils/alerts';
+import { type AlertType, formatAzimuth } from '@//utils/alerts';
 import { formatToDate, formatToTime } from '@//utils/dates';
 import { CameraName } from '@/components/Common/Camera/CameraName';
 import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
@@ -72,39 +72,35 @@ export const AlertCard = ({
             <Typography variant="h3">{t('prefixCardDetection')}</Typography>
           </Stack>
           {alert.sequences.map((sequence) => (
-            <Grid
-              container
+            <Stack
+              direction="row"
               key={sequence.id}
               justifyContent="space-between"
               alignItems="center"
             >
-              <Grid>
-                <Stack direction="row" spacing={1} alignItems="center">
-                  <SequenceLabelChip
-                    isSmall
-                    labelWildfire={sequence.labelWildfire}
-                  />
-                  {sequence.camera && (
-                    <CameraName
-                      name={sequence.camera.name}
-                      angle_of_view={sequence.camera.angle_of_view}
-                    />
-                  )}
-                </Stack>
-              </Grid>
-              <Grid flexGrow={1}>
-                <Stack direction="row" spacing={1} justifyContent="end">
-                  {sequence.azimuth != null && (
-                    <Typography variant="caption" fontWeight={500}>
-                      {sequence.azimuth}°
-                    </Typography>
-                  )}
-                  <Typography variant="caption">
-                    {formatToTime(alert.startedAt)}
-                  </Typography>
-                </Stack>
-              </Grid>
-            </Grid>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <SequenceLabelChip
+                  isSmall
+                  labelWildfire={sequence.labelWildfire}
+                />
+                {sequence.camera && <CameraName camera={sequence.camera} />}
+              </Stack>
+
+              <Stack
+                direction="row"
+                spacing={1}
+                justifyContent="end"
+                flexGrow={1}
+              >
+                <Typography variant="caption" fontWeight={500}>
+                  {formatAzimuth(sequence.coneAzimuth)}
+                </Typography>
+
+                <Typography variant="caption">
+                  {formatToTime(alert.startedAt)}
+                </Typography>
+              </Stack>
+            </Stack>
           ))}
         </CardContent>
       </CardActionArea>

--- a/src/components/Common/Camera/CameraName.tsx
+++ b/src/components/Common/Camera/CameraName.tsx
@@ -1,19 +1,15 @@
-import { Typography, useTheme } from '@mui/material';
+import { Stack, Typography } from '@mui/material';
+
+import type { CameraType } from '@/services/camera';
+import type { CameraFullInfosType } from '@/utils/camera';
 
 interface CameraNameType {
-  name: string;
-  angle_of_view: number | null;
+  camera: CameraType | CameraFullInfosType;
 }
-export const CameraName = ({ name, angle_of_view }: CameraNameType) => {
-  const theme = useTheme();
+export const CameraName = ({ camera }: CameraNameType) => {
   return (
-    <Typography variant="body1">
-      {name}
-      {angle_of_view && (
-        <span
-          style={{ color: theme.palette.secondaryText.main }}
-        >{` (${angle_of_view.toString()}°)`}</span>
-      )}
-    </Typography>
+    <Stack direction="row" alignItems="center" spacing={1}>
+      <Typography variant="body1">{camera.name}</Typography>
+    </Stack>
   );
 };

--- a/src/components/Common/Camera/CamerasListSelectable.tsx
+++ b/src/components/Common/Camera/CamerasListSelectable.tsx
@@ -36,10 +36,7 @@ export const CamerasListSelectable = ({
               </ListItemIcon>
             )}
             <ListItemText inset={camera.id != selectedCameraId}>
-              <CameraName
-                name={camera.name}
-                angle_of_view={camera.angle_of_view}
-              />
+              <CameraName camera={camera} />
             </ListItemText>
           </ListItemButton>
         </ListItem>

--- a/src/components/Dashboard/CameraCard/CameraCard.tsx
+++ b/src/components/Dashboard/CameraCard/CameraCard.tsx
@@ -52,10 +52,7 @@ export const CameraCard = ({
           <Stack direction="row">
             <CardContent sx={{ p: { xs: 1, sm: 2 }, flexGrow: 1 }}>
               <Stack spacing={1}>
-                <CameraName
-                  name={camera.name}
-                  angle_of_view={camera.angle_of_view}
-                />
+                <CameraName camera={camera} />
                 <CameraCardLastPing camera={camera} />
               </Stack>
             </CardContent>
@@ -89,10 +86,7 @@ export const CameraCard = ({
         <Stack direction="row" justifyContent="space-between">
           <CardContent sx={{ p: { xs: 1, sm: 2 }, flexGrow: 1 }}>
             <Stack spacing={1}>
-              <CameraName
-                name={camera.name}
-                angle_of_view={camera.angle_of_view}
-              />
+              <CameraName camera={camera} />
               <CameraCardLastPing camera={camera} />
             </Stack>
           </CardContent>

--- a/src/utils/alerts.test.ts
+++ b/src/utils/alerts.test.ts
@@ -1,0 +1,40 @@
+import { formatAzimuth, formatPosition } from './alerts';
+
+describe('formatConeAzimuth', () => {
+  it('should return empty string if is null', () => {
+    const result = formatAzimuth(null);
+    expect(result).toBe('');
+  });
+
+  it('should return 22° if a float', () => {
+    const result = formatAzimuth(22.4);
+    expect(result).toBe('22°');
+  });
+  it('should return 22.5° if a float with precision of 1', () => {
+    const result = formatAzimuth(22.5, 1);
+    expect(result).toBe('22.5°');
+  });
+});
+describe('formatPosition', () => {
+  it('should return empty string if is null', () => {
+    const result = formatPosition(undefined, undefined);
+    expect(result).toBe('');
+  });
+
+  it('should return one coordinate if lon present', () => {
+    const result = formatPosition(undefined, 12.554128494);
+    expect(result).toBe('-, 12.554128');
+  });
+  it('should return one coordinate if lat present', () => {
+    const result = formatPosition(12.554128494, undefined);
+    expect(result).toBe('12.554128, -');
+  });
+  it('should return both coordinates if present', () => {
+    const result = formatPosition(48.852501257, 2.337761575);
+    expect(result).toBe('48.852501, 2.337762');
+  });
+  it('should return both coordinates if present', () => {
+    const result = formatPosition(48.85251, 2.33776);
+    expect(result).toBe('48.852510, 2.337760');
+  });
+});

--- a/src/utils/alerts.ts
+++ b/src/utils/alerts.ts
@@ -54,3 +54,20 @@ export const convertSequencesToAlerts = (
 export const countUnlabelledSequences = (
   sequences: SequenceWithCameraInfoType[]
 ) => sequences.filter((sequence) => sequence.labelWildfire === null).length;
+
+export const formatAzimuth = (azimuth: number | null, precision = 0) => {
+  return azimuth ? `${azimuth.toFixed(precision)}°` : '';
+};
+
+export const formatPosition = (
+  lat: number | undefined,
+  lon: number | undefined
+) => {
+  if (!lat && !lon) {
+    return '';
+  }
+  return `${formatOneCoordinate(lat)}, ${formatOneCoordinate(lon)}`;
+};
+const formatOneCoordinate = (coordinate: number | undefined) => {
+  return coordinate ? coordinate.toFixed(6) : '-';
+};


### PR DESCRIPTION
- remove angle of view next to camera name
- fix azimuth in the alert info section (display alert azimuth and not camera azimuth)
- create two methods to display an azimuth and coordinates to use across the app