### PR TITLE
feat: change date format for different languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "i18next-browser-languagedetector": "^8.2.0",
     "leaflet": "^1.9.4",
     "lodash": "^4.17.21",
+    "moment": "^2.30.1",
     "moment-timezone": "^0.6.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      moment:
+        specifier: ^2.30.1
+        version: 2.30.1
       moment-timezone:
         specifier: ^0.6.0
         version: 0.6.0

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import ProtectedRoute from './components/Login/ProtectedRoute';
 import { Topbar } from './components/Topbar/Topbar';
 import { AuthProvider } from './context/AuthProvider';
+import { DateLocalizationProvider } from './context/DateLocalizationProvider';
 import { PreferencesProvider } from './context/PreferencesProvider';
 import { AlertsPage } from './pages/AlertsPage';
 import { DashboardPage } from './pages/DashboardPage';
@@ -28,26 +29,28 @@ const App = () => {
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
         <PreferencesProvider>
-          <BrowserRouter>
-            <Stack height={'100vh'}>
-              <Topbar />
-              <Stack overflow={'hidden'} flexGrow={1}>
-                <Routes>
-                  <Route errorElement={<ErrorPage />}>
-                    <Route index element={<Navigate to={DEFAULT_ROUTE} />} />
-                    <Route path="/login" element={<LoginPage />} />
-                    {/* Routes under this cannot be accessed without being logged in */}
-                    <Route element={<ProtectedRoute />}>
-                      <Route path="/alerts" element={<AlertsPage />} />
-                      <Route path="/dashboard" element={<DashboardPage />} />
-                      <Route path="/history" element={<HistoryPage />} />
+          <DateLocalizationProvider>
+            <BrowserRouter>
+              <Stack height={'100vh'}>
+                <Topbar />
+                <Stack overflow={'hidden'} flexGrow={1}>
+                  <Routes>
+                    <Route errorElement={<ErrorPage />}>
+                      <Route index element={<Navigate to={DEFAULT_ROUTE} />} />
+                      <Route path="/login" element={<LoginPage />} />
+                      {/* Routes under this cannot be accessed without being logged in */}
+                      <Route element={<ProtectedRoute />}>
+                        <Route path="/alerts" element={<AlertsPage />} />
+                        <Route path="/dashboard" element={<DashboardPage />} />
+                        <Route path="/history" element={<HistoryPage />} />
+                      </Route>
+                      <Route path="*" element={<ErrorPage is404 />} />
                     </Route>
-                    <Route path="*" element={<ErrorPage is404 />} />
-                  </Route>
-                </Routes>
+                  </Routes>
+                </Stack>
               </Stack>
-            </Stack>
-          </BrowserRouter>
+            </BrowserRouter>
+          </DateLocalizationProvider>
         </PreferencesProvider>
       </AuthProvider>
     </QueryClientProvider>

--- a/src/components/History/HistoryList/HistoryFilters.tsx
+++ b/src/components/History/HistoryList/HistoryFilters.tsx
@@ -1,11 +1,10 @@
-import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import moment from 'moment-timezone';
-import { useTranslation } from 'react-i18next';
+import moment from 'moment/min/moment-with-locales';
+
+import i18n from '@/i18n';
+import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
 
 import type { FiltersType } from '../../../utils/history';
-import { useTranslationPrefix } from '../../../utils/useTranslationPrefix';
 
 interface HistoryFiltersType {
   filters: FiltersType;
@@ -14,14 +13,12 @@ interface HistoryFiltersType {
 
 const getDateFormat = (locale: string) => {
   switch (locale) {
-    case 'en':
-      return 'MM/DD/YYYY';
     case 'fr':
     case 'es':
       return 'DD/MM/YYYY';
-    // TODO: traiter le cas général ? (en-US...)
+    case 'en':
     default:
-      return 'DD/MM/YYYY';
+      return 'MM/DD/YYYY';
   }
 };
 
@@ -29,19 +26,16 @@ export const HistoryFilters = ({ filters, setFilters }: HistoryFiltersType) => {
   const { t } = useTranslationPrefix('history');
   const oneYearAgo = moment().subtract(1, 'year');
 
-  const { i18n } = useTranslation();
-
   return (
-    <LocalizationProvider dateAdapter={AdapterMoment}>
-      <DatePicker
-        label={t('dateField')}
-        sx={{ width: '100%' }}
-        disableFuture
-        minDate={oneYearAgo}
-        value={filters.date}
-        onChange={(newValue) => setFilters({ ...filters, date: newValue })}
-        format={getDateFormat(i18n.language)}
-      />
-    </LocalizationProvider>
+    // Properly localized DatePicker thanks to DateLocalizationProvider in App.tsxs
+    <DatePicker
+      label={t('dateField')}
+      sx={{ width: '100%' }}
+      disableFuture
+      minDate={oneYearAgo}
+      value={filters.date}
+      onChange={(newValue) => setFilters({ ...filters, date: newValue })}
+      format={getDateFormat(i18n.language)}
+    />
   );
 };

--- a/src/context/DateLocalizationProvider.tsx
+++ b/src/context/DateLocalizationProvider.tsx
@@ -1,0 +1,26 @@
+import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import moment from 'moment/min/moment-with-locales';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+export const DateLocalizationProvider: React.FC<React.PropsWithChildren> = ({
+  children,
+}) => {
+  const { i18n } = useTranslation();
+
+  // Set global moment locale when language changes
+  React.useEffect(() => {
+    moment.locale(i18n.language);
+  }, [i18n.language]);
+
+  return (
+    <LocalizationProvider
+      dateAdapter={AdapterMoment}
+      adapterLocale={i18n.language}
+      dateLibInstance={moment}
+    >
+      {children}
+    </LocalizationProvider>
+  );
+};


### PR DESCRIPTION
Ce qui est fait :
- changer le format de la date en fonction de la langue

Ce qui n'est pas fait :
- changer le premier jour de la semaine en fonction de la langue
- changer la langue du composant

Détails :

- changer la premier jour de la semaine :
Pas d'option pour ça, il faut changer la locale du composant

- changer la langue du composant
J'ai essayé beaucoup de choses pour changer la locale du composant, mais ça n'a jamais réussi...

Mes ressources :
- https://mui.com/x/api/date-pickers/date-picker/ -> la doc du date picker
- https://mui.com/x/react-date-pickers/adapters-locale/ -> la doc pour les locales des date pickers

Ce que j'ai tenté :
- installer moment pour pouvoir importer les packages en `import 'moment/locale/de';` et set la locale comme indiqué ici : https://mui.com/x/react-date-pickers/adapters-locale/#with-moment
- utiliser moment.locale('fr') pour forcer le changement de la langue utilisée par moment JS (sans succès)
- et quelques autres trucs mais moins clairs

A noter que j'ai vu des changements de certains éléments, par exemple les jours sont devenus TT en allemand (pour Tag, jour en allemand), donc il y avait bien des changements, mais ça n'a jamais changé la langue du mois.

Bref, je ne sais pas très bien quelle pourrait être la solution... Bon courage au suivant ! 😄
