### PR TITLE
fix: prevent DatePicker from triggering API requests while typing

### DIFF
--- a/src/components/History/HistoryList/HistoryFilters.tsx
+++ b/src/components/History/HistoryList/HistoryFilters.tsx
@@ -40,6 +40,7 @@ export const HistoryFilters = ({ filters, setFilters }: HistoryFiltersType) => {
       onChange={setCurrentValue}
       onAccept={(newValue, context) => {
         if (context.source === 'view') {
+          // Triggers only if a date is selected with the calendar modal
           setFilters({
             ...filters,
             date: newValue,


### PR DESCRIPTION
The DatePicker was firing onChange on every keystroke that produced a valid date, causing premature API requests while users typed the year.

Now the filter is only updated on blur (when user leaves the field) or onAccept (when user picks from calendar or presses Enter).

Fixes #164