### PR TITLE
Fix/issue161/mobile display of alerts player

### DIFF
--- a/src/components/Alerts/AlertDetails/AlertImages/AlertImages.tsx
+++ b/src/components/Alerts/AlertDetails/AlertImages/AlertImages.tsx
@@ -101,13 +101,21 @@ export const AlertImages = ({ sequence }: AlertImagesType) => {
           direction="row"
           justifyContent="space-between"
           alignItems="center"
-          spacing={2}
+          spacing={{ xs: 1, sm: 2 }}
           minHeight={35}
+          useFlexGap
+          sx={{ flexWrap: 'wrap', rowGap: 1 }}
         >
           <Typography variant="h2">
             {formatIsoToTime(sequence.startedAt)}
           </Typography>
-          <Stack spacing={2} alignItems="center" direction="row">
+          <Stack
+            spacing={{ xs: 1, sm: 2 }}
+            alignItems="center"
+            direction="row"
+            useFlexGap
+            sx={{ flexWrap: 'wrap', rowGap: 1 }}
+          >
             <Button
               variant="outlined"
               onClick={() => setDisplayBbox((oldValue) => !oldValue)}

--- a/src/components/Common/SplitButton.tsx
+++ b/src/components/Common/SplitButton.tsx
@@ -74,6 +74,7 @@ export const SplitButton = ({
           aria-label={options[0].label}
           aria-haspopup="menu"
           onClick={handleToggle}
+          sx={{ px: 0 }}
         >
           <ArrowDropDownIcon />
         </Button>


### PR DESCRIPTION
## Issue
Fixes #161 

## Loom
https://www.loom.com/share/e49931d29dc8449792eee1bdebdc4c89

## Screens
Before:
<img width="400" height="370" alt="image" src="https://github.com/user-attachments/assets/88fb82b4-cae8-43ac-b3b5-10324c132688" />

After:
<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/b0956b9b-8f5e-48a9-99c9-00e31c100930" />
