### PR TITLE
fix: display only current day alerts on alerts page (#168)

### DIFF
--- a/src/pages/AlertsPage.tsx
+++ b/src/pages/AlertsPage.tsx
@@ -7,6 +7,7 @@ import appConfig from '@/services/appConfig';
 import { STATUS_ERROR, STATUS_LOADING, STATUS_SUCCESS } from '@/services/axios';
 import { getCameraList } from '@/services/camera';
 import { type AlertType, convertSequencesToAlerts } from '@/utils/alerts';
+import { isDateToday } from '@/utils/dates';
 import { useDetectNewSequences } from '@/utils/useDetectNewSequences';
 
 const ALERTS_LIST_REFRESH_INTERVAL_SECONDS =
@@ -30,12 +31,20 @@ export const AlertsPage = () => {
     queryFn: getCameraList,
   });
 
-  const alertsList: AlertType[] = useMemo(
-    () => convertSequencesToAlerts(sequenceList ?? [], cameraList ?? []),
-    [sequenceList, cameraList]
+  const todaySequences = useMemo(
+    () => (sequenceList ?? []).filter((seq) => isDateToday(seq.started_at)),
+    [sequenceList]
   );
 
-  const { hasNewSequence } = useDetectNewSequences(sequenceList, dataUpdatedAt);
+  const alertsList: AlertType[] = useMemo(
+    () => convertSequencesToAlerts(todaySequences, cameraList ?? []),
+    [todaySequences, cameraList]
+  );
+
+  const { hasNewSequence } = useDetectNewSequences(
+    todaySequences,
+    dataUpdatedAt
+  );
 
   const invalidateAndRefreshData = useCallback(() => {
     void queryClient.invalidateQueries({ queryKey: ['unlabelledSequences'] });

--- a/src/utils/dates.test.ts
+++ b/src/utils/dates.test.ts
@@ -8,6 +8,7 @@ import {
   formatTimeAgo,
   formatTimer,
   formatUnixToTime,
+  isDateToday,
   isDateWithinTheLastXMinutes,
   isStrictlyAfter,
 } from './dates';
@@ -264,5 +265,24 @@ describe('formatTimer', () => {
   it('should return XX:XX:XX if more than a hour', () => {
     const result = formatTimer(3740);
     expect(result).toEqual('01:02:20');
+  });
+});
+
+describe('isDateToday', () => {
+  it('should return false if date is null', () => {
+    const result = isDateToday(null);
+    expect(result).toBeFalsy();
+  });
+  it('should return false if date is yesterday', () => {
+    const result = isDateToday(getPastDateString({ days: 1 }));
+    expect(result).toBeFalsy();
+  });
+  it('should return false if date is in the past', () => {
+    const result = isDateToday('2025-02-25T09:37:03.172325');
+    expect(result).toBeFalsy();
+  });
+  it('should return true if date is now', () => {
+    const result = isDateToday(new Date().toISOString());
+    expect(result).toBeTruthy();
   });
 });

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -118,3 +118,12 @@ export const formatTimer = (nbSeconds: number) => {
   const duration = Duration.fromMillis(nbSeconds * 1000);
   return duration.toFormat('hh:mm:ss');
 };
+
+export const isDateToday = (dateStr: string | null): boolean => {
+  if (!dateStr) {
+    return false;
+  }
+  const date = isoToDatetime(dateStr);
+  const today = DateTime.now();
+  return date.hasSame(today, 'day');
+};


### PR DESCRIPTION
## Summary
- Filter alerts to display only current day's alerts instead of last 24 hours
- Add `isDateToday()` utility function using Luxon for timezone-aware date comparison

## Changes

- **`src/utils/dates.ts`**: Added `isDateToday()` function that compares dates using Luxon's `hasSame(today, 'day')`
- **`src/utils/dates.test.ts`**: Added unit tests for `isDateToday()`
- **`src/pages/AlertsPage.tsx`**: Filter sequences to keep only today's alerts before displaying

## Impact in the app

### Before
<img width="382" height="676" alt="Capture d’écran 2026-02-01 à 20 31 39" src="https://github.com/user-attachments/assets/82958574-90d4-4332-a64d-0e3dc444ae3c" />

### After
<img width="395" height="530" alt="Capture d’écran 2026-02-01 à 20 31 56" src="https://github.com/user-attachments/assets/b1cd650f-c7e4-4100-98e7-5c2ce9f60d81" />


Closes #168
