### PR TITLE
fix: minor ux ui change for mobile mode

### DIFF
--- a/src/components/Alerts/AlertDetails/AlertHeader.tsx
+++ b/src/components/Alerts/AlertDetails/AlertHeader.tsx
@@ -1,6 +1,6 @@
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { IconButton, Stack, Typography } from '@mui/material';
-import type { Dispatch, SetStateAction } from 'react';
+import { type Dispatch, type SetStateAction } from 'react';
 
 import smallLogo from '@/assets/small-logo.png';
 import {
@@ -65,19 +65,22 @@ export const AlertHeader = ({
     <>
       {isMobile ? (
         <Stack spacing={1}>
-          <Stack direction="row" spacing={1} justifyContent="space-between">
+          <Stack
+            direction="row"
+            spacing={1}
+            alignItems="center"
+            flexWrap="wrap"
+          >
             <IconButton
               aria-label={t('titleButtonBackAlt')}
               onClick={resetAlert}
             >
               <ArrowBackIcon />
             </IconButton>
-            {SequenceSelectorComponent}
-          </Stack>
-
-          <Stack direction="row" flexWrap="wrap" spacing={2}>
             {Title}
+            {SequenceSelectorComponent}
             {SequenceLabel}
+            {SequenceSelectorComponent}
           </Stack>
         </Stack>
       ) : (

--- a/src/components/Alerts/AlertDetails/AlertImages/AlertImages.tsx
+++ b/src/components/Alerts/AlertDetails/AlertImages/AlertImages.tsx
@@ -78,7 +78,7 @@ export const AlertImages = ({ sequence }: AlertImagesType) => {
       link.rel = 'noopener noreferrer';
       document.body.appendChild(link);
       link.click();
-      document.body.removeChild(link);
+      link.remove();
     }
   };
 

--- a/src/components/Alerts/AlertDetails/AlertImages/DetectionImageWithBoundingBox.tsx
+++ b/src/components/Alerts/AlertDetails/AlertImages/DetectionImageWithBoundingBox.tsx
@@ -85,7 +85,13 @@ export const DetectionImageWithBoundingBox = ({
   };
 
   return (
-    <div style={{ position: 'relative', display: 'inline-block' }}>
+    <div
+      style={{
+        position: 'relative',
+        display: 'inline-block',
+        justifyItems: 'center',
+      }}
+    >
       <TransformWrapper
         limitToBounds
         centerZoomedOut

--- a/src/components/Topbar/MobileTopbar.tsx
+++ b/src/components/Topbar/MobileTopbar.tsx
@@ -1,18 +1,18 @@
 import MenuIcon from '@mui/icons-material/Menu';
 import {
   AppBar,
-  Grid,
   IconButton,
   Slide,
+  Stack,
   Toolbar,
   useScrollTrigger,
 } from '@mui/material';
 import { useState } from 'react';
 
 import logo from '@/assets/logo.svg';
+import { useAuth } from '@/context/useAuth';
+import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
 
-import { useAuth } from '../../context/useAuth';
-import { useTranslationPrefix } from '../../utils/useTranslationPrefix';
 import { MobileTopbarDrawer } from './MobileTopbarDrawer';
 
 export const MobileTopbar = () => {
@@ -34,16 +34,8 @@ export const MobileTopbar = () => {
       <Slide appear={false} direction="down" in={!shouldHideTopbar}>
         <AppBar>
           <Toolbar disableGutters>
-            <Grid
-              container
-              justifyContent="space-between"
-              sx={{
-                flexGrow: 1,
-                paddingX: '1rem',
-                alignItems: 'center',
-              }}
-            >
-              {isLoggedIn ? (
+            <Stack flexGrow={1} direction="row" paddingX="1rem">
+              {isLoggedIn && (
                 <IconButton
                   edge="start"
                   color="inherit"
@@ -55,10 +47,9 @@ export const MobileTopbar = () => {
                 >
                   <MenuIcon />
                 </IconButton>
-              ) : (
-                <img height="30px" src={logo} alt="Logo" />
               )}
-            </Grid>
+              <img height="30px" src={logo} alt="Logo" />
+            </Stack>
           </Toolbar>
         </AppBar>
       </Slide>

--- a/src/utils/alerts.ts
+++ b/src/utils/alerts.ts
@@ -172,3 +172,11 @@ export const hasNewSequenceSince = (
     return sequenceCreationTime >= previousDataUpdatedAt;
   });
 };
+
+export const isInTheList = (
+  alertsList: AlertType[],
+  alert: AlertType | null
+) => {
+  const indexSelectedAlert = alertsList.findIndex((a) => a.id === alert?.id);
+  return indexSelectedAlert != -1;
+};


### PR DESCRIPTION
In mobile mode : 
- Add the icon in the topbar
- Change order of elements in the header
- Add the selected alert as a search param in the URL to be able to click "back" on mobile to come back to the alert list


Before: 
<img width="318" height="533" alt="image" src="https://github.com/user-attachments/assets/8a96ca5b-0f24-4dac-a323-969b8c99e79d" />

After
<img width="364" height="544" alt="Capture d&#39;écran 2026-02-07 174626" src="https://github.com/user-attachments/assets/ac78f9e0-4e77-4b48-ba1d-8bb5de421d80" />
<img width="368" height="576" alt="Capture d&#39;écran 2026-02-07 174606" src="https://github.com/user-attachments/assets/04fb3888-b9c5-48a6-baea-95bdf7be3ea2" />
