### PR TITLE
fix: filter poses without patrol_id

### DIFF
--- a/src/components/Live/LiveContent/StreamActions/QuickActions.tsx
+++ b/src/components/Live/LiveContent/StreamActions/QuickActions.tsx
@@ -86,6 +86,7 @@ export const QuickActions = ({
           <ButtonGroup>
             {poses
               .filter((pose) => pose.patrol_id != null)
+              .sort((p1, p2) => p1.azimuth - p2.azimuth)
               .map((pose) => (
                 <Button
                   key={pose.id}

--- a/src/utils/camera.ts
+++ b/src/utils/camera.ts
@@ -49,12 +49,15 @@ const aggregateCameraData = (
   const cameraInfosFromPi = extraData.find(
     (cameraFromPi) => cameraFromPi.name == camera.name
   );
+  let poses: PoseCameraType[];
+  if (camera.poses && camera.poses.length != 0) {
+    poses = camera.poses.filter((pose) => pose.patrol_id != null);
+  } else {
+    poses = buildPosesFromPiData(camera.id, cameraInfosFromPi);
+  }
   return {
     ...camera,
-    poses:
-      camera.poses?.length == 0
-        ? buildPosesFromPiData(camera.id, cameraInfosFromPi)
-        : camera.poses,
+    poses,
     ip: cameraInfosFromPi?.ip,
     type: cameraInfosFromPi?.type,
   };


### PR DESCRIPTION
- temporary fix : filter poses without patrol_id (thoses poses will be inactive in future version)
- sort poses displayed on action bar
<img width="1015" height="291" alt="image" src="https://github.com/user-attachments/assets/a164e47a-bab0-49c4-9e86-5d269851ef42" />
