### PR TITLE
feat: full screen livestreaming and fix reload

### DIFF
--- a/src/components/Live/LiveContainer.tsx
+++ b/src/components/Live/LiveContainer.tsx
@@ -102,7 +102,7 @@ export const LiveContainer = ({
   return (
     <>
       <LiveErrorSnackbar />
-      <Stack>
+      <Stack height="100%">
         <HeadRow
           onClose={onClose}
           isStreamingLaunched={isStreamingLaunched}
@@ -111,8 +111,8 @@ export const LiveContainer = ({
           }
         />
         {isStreamingLaunched ? (
-          <Grid container p={2} spacing={2} flexGrow={1}>
-            <Grid size={9}>
+          <Grid container spacing={2} flexGrow={1}>
+            <Grid size={8}>
               <LiveStreamPanel
                 urlStreaming={urlStreaming}
                 setIsStreamVideoInterrupted={setIsStreamVideoInterrupted}
@@ -120,7 +120,7 @@ export const LiveContainer = ({
                 alert={alert}
               />
             </Grid>
-            <Grid size={3}>
+            <Grid size={4}>
               <LiveControlPanel
                 sites={sites}
                 selectedSite={selectedSite}

--- a/src/components/Live/LiveContent/HeadRow/HeadRow.tsx
+++ b/src/components/Live/LiveContent/HeadRow/HeadRow.tsx
@@ -21,7 +21,12 @@ export const HeadRow = ({
   return (
     <Alert
       severity={isStreamingRunning ? 'warning' : 'info'}
-      sx={{ margin: 0, display: 'flex', alignItems: 'center' }}
+      sx={{
+        margin: 0,
+        display: 'flex',
+        alignItems: 'center',
+        borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
+      }}
       action={
         <Button variant="outlined" color="primary" onClick={onClose}>
           {t('buttonClose')}

--- a/src/components/Live/LiveContent/LiveControlPanel.tsx
+++ b/src/components/Live/LiveContent/LiveControlPanel.tsx
@@ -1,4 +1,4 @@
-import { Stack } from '@mui/material';
+import { Stack, useTheme } from '@mui/material';
 
 import { type AlertType, getSequenceByCameraId } from '@/utils/alerts';
 import type { CameraFullInfosType, SiteType } from '@/utils/camera';
@@ -22,13 +22,19 @@ export const LiveControlPanel = ({
   selectedCamera,
   alert,
 }: LiveControlPanelProps) => {
+  const theme = useTheme();
   const currentSequence =
     alert && selectedCamera
       ? getSequenceByCameraId(alert, selectedCamera.id)
       : undefined;
 
   return (
-    <Stack spacing={1} height="100%">
+    <Stack
+      spacing={1}
+      height="100%"
+      p={2}
+      sx={{ backgroundColor: theme.palette.customBackground.light }}
+    >
       {alert ? (
         <SelectionCameraWithAlert
           sites={sites}

--- a/src/components/Live/LiveContent/LiveStreamPanel.tsx
+++ b/src/components/Live/LiveContent/LiveStreamPanel.tsx
@@ -49,7 +49,8 @@ export const LiveStreamPanel = ({
 
   const initialMove = useMemo(
     () => getMoveToAzimuthFromAlert(camera, alert),
-    [alert, camera]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
   );
 
   const mediaMtxInterrupted =
@@ -96,7 +97,7 @@ export const LiveStreamPanel = ({
     );
 
   return (
-    <Stack spacing={1} height="100%">
+    <Stack spacing={1} height="100%" p={2}>
       {statusStreamingVideo === STATUS_ERROR && (
         <Typography variant="body2">{t('errorNoStreaming')}</Typography>
       )}

--- a/src/components/Live/ModalLiveWrapper.tsx
+++ b/src/components/Live/ModalLiveWrapper.tsx
@@ -1,4 +1,4 @@
-import { Dialog, DialogContent } from '@mui/material';
+import { Dialog, DialogContent, useTheme } from '@mui/material';
 import { type ReactNode, useState } from 'react';
 
 import type { AlertType } from '@/utils/alerts';
@@ -18,6 +18,7 @@ export const ModalLiveWrapper = ({
   children,
 }: ModalLiveWrapperProps) => {
   const [openLive, setOpenLive] = useState(false);
+  const theme = useTheme();
 
   // Created here to keep the queue intact when the modal is closed
 
@@ -36,16 +37,17 @@ export const ModalLiveWrapper = ({
     <>
       {children(handleOpen)}
       <ActionsOnCameraContextProvider>
-        <Dialog open={openLive} onClose={handleClose} maxWidth="lg" fullWidth>
-          <DialogContent
-            sx={{
-              padding: 0,
-              minHeight: '90vh',
-              '& > .MuiStack-root': {
-                minHeight: '90vh',
-              },
-            }}
-          >
+        <Dialog
+          open={openLive}
+          onClose={handleClose}
+          fullScreen
+          sx={{
+            '.MuiDialog-paper': {
+              background: theme.palette.background.default,
+            },
+          }}
+        >
+          <DialogContent sx={{ padding: 0 }}>
             <LiveContainer
               onClose={() => setOpenLive(false)}
               cameraName={cameraName}


### PR DESCRIPTION
- Transform xl modal into full screen modal (adapt colors and enlarge column with map)
- Fix bug reload when alert is updated (#204 )
<img width="1918" height="977" alt="image" src="https://github.com/user-attachments/assets/da95146b-8061-492b-9517-ef17c043257c" />
