### PR TITLE
feat: Sort detections

### DIFF
--- a/src/components/Alerts/AlertDetails/AlertImages/AlertImages.tsx
+++ b/src/components/Alerts/AlertDetails/AlertImages/AlertImages.tsx
@@ -30,6 +30,7 @@ export const AlertImages = ({ sequence }: AlertImagesType) => {
   const { t } = useTranslationPrefix('alerts');
   const [lastSeenAt, setLastSeenAt] = useState<string | null>(null);
   const [displayBbox, setDisplayBbox] = useState(true);
+  const [orderDetectionsByDesc, setOrderDetectionsByDesc] = useState(true);
   const [currentDetection, setCurrentDetection] =
     useState<DetectionType | null>(null);
   const queryClient = useQueryClient();
@@ -40,9 +41,9 @@ export const AlertImages = ({ sequence }: AlertImagesType) => {
     isSuccess,
     data: detectionsList,
   } = useQuery({
-    queryKey: ['detections', sequence.id],
+    queryKey: ['detections', sequence.id, orderDetectionsByDesc],
     queryFn: async () => {
-      return await getDetectionsBySequence(sequence.id);
+      return await getDetectionsBySequence(sequence.id, orderDetectionsByDesc);
     },
     refetchOnWindowFocus: false,
   });
@@ -155,6 +156,8 @@ export const AlertImages = ({ sequence }: AlertImagesType) => {
               firstConfidentDetectionIndex={getFirstConfidentDetectionIndex(
                 detectionsList
               )}
+              orderDetectionsByDesc={orderDetectionsByDesc}
+              setOrderDetectionsByDesc={setOrderDetectionsByDesc}
             />
           )}
         </Grid>

--- a/src/components/Alerts/AlertDetails/AlertImages/AlertImagesPlayer.tsx
+++ b/src/components/Alerts/AlertDetails/AlertImages/AlertImagesPlayer.tsx
@@ -1,13 +1,21 @@
 import PauseIcon from '@mui/icons-material/Pause';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import { Box, IconButton, Slider, Stack, useTheme } from '@mui/material';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 
 import type { DetectionType } from '@/services/alerts';
 import appConfig from '@/services/appConfig';
 import { convertIsoToUnix, formatIsoToTime } from '@/utils/dates';
 import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
 
+import { AlertOrderButton } from './AlertOrderButton';
 import { DetectionImageWithBoundingBox } from './DetectionImageWithBoundingBox';
 
 interface AlertImagesPlayerType {
@@ -16,6 +24,8 @@ interface AlertImagesPlayerType {
   displayBbox: boolean;
   onSelectedDetectionChange: (detection: DetectionType | null) => void;
   firstConfidentDetectionIndex: number;
+  orderDetectionsByDesc: boolean;
+  setOrderDetectionsByDesc: Dispatch<SetStateAction<boolean>>;
 }
 
 const ALERTS_PLAYER_INTERVAL_MILLISECONDS =
@@ -27,6 +37,8 @@ export const AlertImagesPlayer = ({
   displayBbox,
   onSelectedDetectionChange,
   firstConfidentDetectionIndex,
+  orderDetectionsByDesc,
+  setOrderDetectionsByDesc,
 }: AlertImagesPlayerType) => {
   const [selectedDetection, setSelectedDetection] =
     useState<DetectionType | null>(null);
@@ -152,6 +164,10 @@ export const AlertImagesPlayer = ({
                 }}
               />
             </Box>
+            <AlertOrderButton
+              orderDetectionsByDesc={orderDetectionsByDesc}
+              setOrderDetectionsByDesc={setOrderDetectionsByDesc}
+            />
           </Stack>
         </Stack>
       )}

--- a/src/components/Alerts/AlertDetails/AlertImages/AlertImagesPlayer.tsx
+++ b/src/components/Alerts/AlertDetails/AlertImages/AlertImagesPlayer.tsx
@@ -139,6 +139,10 @@ export const AlertImagesPlayer = ({
             >
               {isPlaying ? <PauseIcon /> : <PlayArrowIcon />}
             </IconButton>
+            <AlertOrderButton
+              orderDetectionsByDesc={orderDetectionsByDesc}
+              setOrderDetectionsByDesc={setOrderDetectionsByDesc}
+            />
             <Box sx={{ flexGrow: 1, width: '100%', mr: 2, px: 3, pt: 3 }}>
               <Slider
                 value={convertIsoToUnix(selectedDetection.created_at)}
@@ -164,10 +168,6 @@ export const AlertImagesPlayer = ({
                 }}
               />
             </Box>
-            <AlertOrderButton
-              orderDetectionsByDesc={orderDetectionsByDesc}
-              setOrderDetectionsByDesc={setOrderDetectionsByDesc}
-            />
           </Stack>
         </Stack>
       )}

--- a/src/components/Alerts/AlertDetails/AlertImages/AlertOrderButton.tsx
+++ b/src/components/Alerts/AlertDetails/AlertImages/AlertOrderButton.tsx
@@ -1,0 +1,79 @@
+import Check from '@mui/icons-material/Check';
+import SwapVertIcon from '@mui/icons-material/SwapVert';
+import IconButton from '@mui/material/IconButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import { type Dispatch, type SetStateAction, useState } from 'react';
+
+import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
+
+interface AlertOrderButtonProps {
+  orderDetectionsByDesc: boolean;
+  setOrderDetectionsByDesc: Dispatch<SetStateAction<boolean>>;
+}
+
+export const AlertOrderButton = ({
+  orderDetectionsByDesc,
+  setOrderDetectionsByDesc,
+}: AlertOrderButtonProps) => {
+  const { t } = useTranslationPrefix('alerts.detectionsOrder');
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <>
+      <IconButton
+        aria-label={t('buttonLabel')}
+        size="large"
+        aria-controls={open ? 'basic-menu' : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        onClick={handleClick}
+      >
+        <SwapVertIcon />
+      </IconButton>
+      <Menu
+        id="basic-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+        slotProps={{
+          list: {
+            'aria-labelledby': 'basic-button',
+          },
+        }}
+      >
+        <MenuItem
+          onClick={() => {
+            setOrderDetectionsByDesc(false);
+            handleClose();
+          }}
+        >
+          <ListItemIcon>{!orderDetectionsByDesc && <Check />}</ListItemIcon>
+          {t('recentFirst')}
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            setOrderDetectionsByDesc(true);
+            handleClose();
+          }}
+        >
+          <ListItemIcon>{orderDetectionsByDesc && <Check />}</ListItemIcon>
+          {t('latestFirst')}
+        </MenuItem>
+      </Menu>
+    </>
+  );
+};

--- a/src/components/Alerts/AlertDetails/AlertImages/AlertOrderButton.tsx
+++ b/src/components/Alerts/AlertDetails/AlertImages/AlertOrderButton.tsx
@@ -37,6 +37,7 @@ export const AlertOrderButton = ({
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
         onClick={handleClick}
+        sx={{ transform: 'rotate(90deg)' }}
       >
         <SwapVertIcon />
       </IconButton>

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -139,6 +139,11 @@
       "detectionImageAlt": "Erkennung",
       "deleting": "Wird gelöscht...",
       "adding": "Wird hinzugefügt..."
+    },
+    "detectionsOrder": {
+      "buttonLabel": "Erkennungen sortieren",
+      "recentFirst": "Älteste zuerst anzeigen",
+      "latestFirst": "Neueste zuerst anzeigen"
     }
   },
   "history": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -138,6 +138,11 @@
       "detectionImageAlt": "Detection",
       "deleting": "Deleting...",
       "adding": "Adding..."
+    },
+    "detectionsOrder": {
+      "buttonLabel": "Sort detections",
+      "recentFirst": "Display oldest first",
+      "latestFirst": "Display newest first"
     }
   },
   "history": {

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -138,6 +138,11 @@
       "detectionImageAlt": "Detección",
       "deleting": "Eliminando...",
       "adding": "Agregando..."
+    },
+    "detectionsOrder": {
+      "buttonLabel": "Ordenar detecciones",
+      "recentFirst": "Mostrar primero las más antiguas",
+      "latestFirst": "Mostrar primero las más recientes"
     }
   },
   "history": {

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -138,6 +138,11 @@
       "detectionImageAlt": "Détection",
       "deleting": "Suppression...",
       "adding": "Ajout..."
+    },
+    "detectionsOrder": {
+      "buttonLabel": "Trier les détections",
+      "recentFirst": "Afficher les plus anciennes en premier",
+      "latestFirst": "Afficher  les plus récentes en premier"
     }
   },
   "history": {

--- a/src/services/alerts.ts
+++ b/src/services/alerts.ts
@@ -107,10 +107,13 @@ export const getAlertsByFilters = async (
 };
 
 export const getDetectionsBySequence = async (
-  sequenceId: number
+  sequenceId: number,
+  isDesc = true
 ): Promise<DetectionType[]> => {
   return apiInstance
-    .get(`/api/v1/sequences/${sequenceId.toString()}/detections`)
+    .get(`/api/v1/sequences/${sequenceId.toString()}/detections`, {
+      params: { desc: isDesc },
+    })
     .then((response: AxiosResponse) => {
       try {
         const result = apiDetectionListResponseSchema.safeParse(response.data);


### PR DESCRIPTION
- Add icon on the end of the line with player : 
<img width="1917" height="902" alt="image" src="https://github.com/user-attachments/assets/d5d55301-e419-4d7e-8e51-00f8c8658d3d" />

- Add menu to select order : 
<img width="1917" height="898" alt="image" src="https://github.com/user-attachments/assets/f937b218-ca29-4bd7-9ea8-b10a5d14555c" />

- Connect the selected option to api call to retrieve detections
Edit : 

<img width="1538" height="882" alt="image" src="https://github.com/user-attachments/assets/fb8b2a1b-c302-447d-ad63-097a15f1afc6" />
