### PR TITLE
fix(live): allow preset pose with patrol_id 0 to be clicked

### DIFF
--- a/src/components/Live/LiveContent/StreamActions/QuickActions.tsx
+++ b/src/components/Live/LiveContent/StreamActions/QuickActions.tsx
@@ -85,15 +85,14 @@ export const QuickActions = ({
           <ExploreOutlinedIcon />
           <ButtonGroup>
             {poses
-              .filter(
-                (pose): pose is PoseCameraType & { patrol_id: number } =>
-                  pose.patrol_id != null
-              )
+              .filter((pose) => pose.patrol_id != null)
               .sort((p1, p2) => p1.azimuth - p2.azimuth)
               .map((pose) => (
                 <Button
                   key={pose.id}
-                  onClick={() => onClickDirection(pose.patrol_id)}
+                  onClick={() =>
+                    pose.patrol_id != null && onClickDirection(pose.patrol_id)
+                  }
                 >
                   <Typography p="2px">{pose.azimuth}°</Typography>
                 </Button>

--- a/src/components/Live/LiveContent/StreamActions/QuickActions.tsx
+++ b/src/components/Live/LiveContent/StreamActions/QuickActions.tsx
@@ -85,14 +85,15 @@ export const QuickActions = ({
           <ExploreOutlinedIcon />
           <ButtonGroup>
             {poses
-              .filter((pose) => pose.patrol_id != null)
+              .filter(
+                (pose): pose is PoseCameraType & { patrol_id: number } =>
+                  pose.patrol_id != null
+              )
               .sort((p1, p2) => p1.azimuth - p2.azimuth)
               .map((pose) => (
                 <Button
                   key={pose.id}
-                  onClick={() =>
-                    pose.patrol_id != null && onClickDirection(pose.patrol_id)
-                  }
+                  onClick={() => onClickDirection(pose.patrol_id)}
                 >
                   <Typography p="2px">{pose.azimuth}°</Typography>
                 </Button>

--- a/src/components/Live/LiveContent/StreamActions/QuickActions.tsx
+++ b/src/components/Live/LiveContent/StreamActions/QuickActions.tsx
@@ -91,7 +91,7 @@ export const QuickActions = ({
                 <Button
                   key={pose.id}
                   onClick={() =>
-                    pose.patrol_id && onClickDirection(pose.patrol_id)
+                    pose.patrol_id != null && onClickDirection(pose.patrol_id)
                   }
                 >
                   <Typography p="2px">{pose.azimuth}°</Typography>


### PR DESCRIPTION
## Summary
- The preset pose buttons in QuickActions filter poses with `patrol_id != null`, so a pose with `patrol_id: 0` rendered a button. The click handler used a truthy check (`pose.patrol_id && ...`), which short-circuited on 0 and made the button do nothing.
- Use an explicit null check, then narrow `patrol_id` via a type predicate in the filter so the click handler can drop the redundant guard.