### PR TITLE
fix: mobile style

### DIFF
--- a/src/components/Alerts/AlertDetails/AlertContainer.tsx
+++ b/src/components/Alerts/AlertDetails/AlertContainer.tsx
@@ -1,5 +1,5 @@
 import ShareIcon from '@mui/icons-material/Share';
-import { Chip, Grid, Tooltip, useTheme } from '@mui/material';
+import { Button, Grid, Tooltip, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 
 import {
@@ -26,7 +26,6 @@ export const AlertContainer = ({
   alert,
   resetAlert,
 }: AlertContainerType) => {
-  const theme = useTheme();
   const { t } = useTranslationPrefix('alerts');
   const [selectedSequence, setSelectedSequence] =
     useState<SequenceWithCameraInfoType | null>(null);
@@ -71,19 +70,13 @@ export const AlertContainer = ({
               placement="top-end"
               title={t('shareLinkCopied')}
             >
-              <Chip
-                icon={<ShareIcon />}
-                label={t('buttonShare')}
-                variant="filled"
-                size="medium"
-                clickable
+              <Button
+                startIcon={<ShareIcon />}
+                variant="text"
                 onClick={handleShare}
-                sx={{
-                  '& .MuiChip-label': {
-                    font: theme.typography.body1,
-                  },
-                }}
-              />
+              >
+                <Typography variant="body1">{t('buttonShare')}</Typography>
+              </Button>
             </Tooltip>
           </Grid>
           <Grid size={{ xs: 12, lg: 8 }}>

--- a/src/components/Alerts/AlertDetails/AlertContainer.tsx
+++ b/src/components/Alerts/AlertDetails/AlertContainer.tsx
@@ -1,5 +1,5 @@
 import ShareIcon from '@mui/icons-material/Share';
-import { Button, Grid, Tooltip, Typography } from '@mui/material';
+import { Button, Grid, Tooltip } from '@mui/material';
 import { useEffect, useState } from 'react';
 
 import {
@@ -75,7 +75,7 @@ export const AlertContainer = ({
                 variant="text"
                 onClick={handleShare}
               >
-                <Typography variant="body1">{t('buttonShare')}</Typography>
+                {t('buttonShare')}
               </Button>
             </Tooltip>
           </Grid>

--- a/src/components/Alerts/AlertDetails/AlertImages/AlertImages.tsx
+++ b/src/components/Alerts/AlertDetails/AlertImages/AlertImages.tsx
@@ -1,6 +1,5 @@
 import { Visibility, VisibilityOff } from '@mui/icons-material';
 import DownloadIcon from '@mui/icons-material/Download';
-import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
 import Grid from '@mui/material/Grid';
 import Paper from '@mui/material/Paper';
@@ -10,6 +9,7 @@ import Typography from '@mui/material/Typography';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useState } from 'react';
 
+import { ResponsiveButton } from '@/components/Common/ResponsiveButton';
 import {
   SplitButton,
   type SplitButtonOption,
@@ -117,13 +117,15 @@ export const AlertImages = ({ sequence }: AlertImagesType) => {
             useFlexGap
             sx={{ flexWrap: 'wrap', rowGap: 1 }}
           >
-            <Button
+            <ResponsiveButton
               variant="outlined"
               onClick={() => setDisplayBbox((oldValue) => !oldValue)}
               startIcon={displayBbox ? <VisibilityOff /> : <Visibility />}
             >
-              {displayBbox ? t('buttonHideBBox') : t('buttonDisplayBBox')}
-            </Button>
+              <span className="Mui-label">
+                {displayBbox ? t('buttonHideBBox') : t('buttonDisplayBBox')}
+              </span>
+            </ResponsiveButton>
             <SplitButton
               label={t('buttonImageDownload')}
               options={downloadOptions}

--- a/src/components/Alerts/AlertLabel/SequenceLabelChip.tsx
+++ b/src/components/Alerts/AlertLabel/SequenceLabelChip.tsx
@@ -72,7 +72,11 @@ export const SequenceLabelChip = ({
       sx={{
         '& .MuiChip-label': {
           font: theme.typography.body1,
+          display: 'block',
+          whiteSpace: 'normal',
         },
+        minHeight: '2rem',
+        height: 'auto',
       }}
     />
   );

--- a/src/components/Alerts/AlertLabel/SequenceLabelModal.tsx
+++ b/src/components/Alerts/AlertLabel/SequenceLabelModal.tsx
@@ -83,6 +83,9 @@ export const SequenceLabelModal = ({
                   value={value}
                   control={<Radio />}
                   label={<SequenceLabelChip labelWildfire={value} />}
+                  sx={{
+                    paddingBottom: 1,
+                  }}
                 />
               ))}
             </RadioGroup>

--- a/src/components/Common/ResponsiveButton.tsx
+++ b/src/components/Common/ResponsiveButton.tsx
@@ -11,7 +11,7 @@ export const ResponsiveButton = (props: ButtonProps) => {
           '& .MuiButton-startIcon': {
             margin: 0,
           },
-          '& .buttonText': {
+          '& .Mui-label': {
             display: 'none',
           },
         },

--- a/src/components/Common/ResponsiveButton.tsx
+++ b/src/components/Common/ResponsiveButton.tsx
@@ -1,0 +1,23 @@
+import { useTheme } from '@mui/material';
+import Button, { type ButtonProps } from '@mui/material/Button';
+
+export const ResponsiveButton = (props: ButtonProps) => {
+  const theme = useTheme();
+  return (
+    <Button
+      {...props}
+      sx={{
+        [theme.breakpoints.down('sm')]: {
+          '& .MuiButton-startIcon': {
+            margin: 0,
+          },
+          '& .buttonText': {
+            display: 'none',
+          },
+        },
+      }}
+    />
+  );
+};
+
+export default ResponsiveButton;

--- a/src/components/Common/SplitButton.tsx
+++ b/src/components/Common/SplitButton.tsx
@@ -10,6 +10,8 @@ import Popper from '@mui/material/Popper';
 import type { ReactElement } from 'react';
 import { useRef, useState } from 'react';
 
+import ResponsiveButton from './ResponsiveButton';
+
 export interface SplitButtonOption {
   label: string;
   onClick?: () => void;
@@ -64,9 +66,9 @@ export const SplitButton = ({
         aria-label={label}
         size={size}
       >
-        <Button startIcon={startIcon} onClick={handleToggle}>
-          {label}
-        </Button>
+        <ResponsiveButton startIcon={startIcon} onClick={handleToggle}>
+          <span className="Mui-label">{label}</span>
+        </ResponsiveButton>
         <Button
           size={'small'}
           aria-controls={open ? 'split-button-menu' : undefined}

--- a/src/components/Dashboard/OcclusionMaskModal/DashboardOcclusionMaskModal.tsx
+++ b/src/components/Dashboard/OcclusionMaskModal/DashboardOcclusionMaskModal.tsx
@@ -30,6 +30,7 @@ import {
   deleteOcclusionMask,
   getOcclusionMasksByPose,
 } from '@/services/occlusionMasks';
+import { formatAzimuth } from '@/utils/alerts';
 import { getNonOverlappingMasksWithIds } from '@/utils/occlusionMasks';
 import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
 
@@ -217,7 +218,7 @@ export const DashboardOcclusionMaskModal = ({
                       }
                       onClick={() => setSelectedPoseId(pose.id)}
                     >
-                      {pose.azimuth}°
+                      {formatAzimuth(pose.azimuth)}
                     </Button>
                   ))}
                 </ButtonGroup>


### PR DESCRIPTION
- Fix #211 : Use icon button on the alert page for mobile
Before :  
<img width="386" height="805" alt="image" src="https://github.com/user-attachments/assets/2b2d76eb-1bed-4286-8b52-8c52ea26275a" />

After: 
<img width="378" height="736" alt="image" src="https://github.com/user-attachments/assets/3e194897-d69a-4fb4-8619-b10fa7c47c58" />


- Fix #180 : label modal on mobile
Before:
<img width="395" height="785" alt="image" src="https://github.com/user-attachments/assets/54f06d23-e2c1-4539-95b7-4804b4b04772" />

After : 
<img width="402" height="776" alt="Capture d&#39;écran 2026-05-03 193602" src="https://github.com/user-attachments/assets/c76dad78-615f-46f1-aaab-a49ca15c7914" />

- Fix formatting in the occlusion mask modal
