### PR TITLE
Feat/add csv export

### DIFF
--- a/src/components/History/HistoryList/HistoryExport.tsx
+++ b/src/components/History/HistoryList/HistoryExport.tsx
@@ -1,4 +1,3 @@
-import DownloadIcon from '@mui/icons-material/Download';
 import { Button, Stack, Typography } from '@mui/material';
 import { useState } from 'react';
 
@@ -17,7 +16,6 @@ export const HistoryExport = () => {
         <Button
           variant="contained"
           color="primary"
-          startIcon={<DownloadIcon />}
           onClick={() => setOpen(true)}
         >
           {t('button')}

--- a/src/components/History/HistoryList/HistoryExport.tsx
+++ b/src/components/History/HistoryList/HistoryExport.tsx
@@ -1,0 +1,29 @@
+import DownloadIcon from '@mui/icons-material/Download';
+import { Button, Stack, Typography } from '@mui/material';
+import { useState } from 'react';
+
+import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
+
+import { HistoryExportModal } from './HistoryExportModal';
+
+export const HistoryExport = () => {
+  const { t } = useTranslationPrefix('history.export');
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Stack spacing={1}>
+        <Typography variant="h2">{t('title')}</Typography>
+        <Button
+          variant="contained"
+          color="primary"
+          startIcon={<DownloadIcon />}
+          onClick={() => setOpen(true)}
+        >
+          {t('button')}
+        </Button>
+      </Stack>
+      <HistoryExportModal open={open} onClose={() => setOpen(false)} />
+    </>
+  );
+};

--- a/src/components/History/HistoryList/HistoryExportModal.tsx
+++ b/src/components/History/HistoryList/HistoryExportModal.tsx
@@ -1,0 +1,135 @@
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import type { PickerValue } from '@mui/x-date-pickers/internals';
+import { useMutation } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+
+import i18n from '@/i18n';
+import { exportAlerts } from '@/services/alerts';
+import {
+  formatDateToApi,
+  getLocalizedDateFormat,
+  getNowMinusOneYear,
+} from '@/utils/dates';
+import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
+
+interface HistoryExportModalType {
+  open: boolean;
+  onClose: () => void;
+}
+
+const triggerCsvDownload = (blob: Blob, fileName: string) => {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileName;
+  link.rel = 'noopener noreferrer';
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+};
+
+export const HistoryExportModal = ({
+  open,
+  onClose,
+}: HistoryExportModalType) => {
+  const { t } = useTranslationPrefix('history.export');
+  const oneYearAgo = getNowMinusOneYear();
+  const [fromDate, setFromDate] = useState<PickerValue>(null);
+  const [toDate, setToDate] = useState<PickerValue>(null);
+
+  const { mutate, reset, isPending, isError } = useMutation({
+    mutationFn: ({
+      fromDateStr,
+      toDateStr,
+    }: {
+      fromDateStr: string;
+      toDateStr: string;
+    }) => exportAlerts(fromDateStr, toDateStr),
+    onSuccess: (blob, { fromDateStr, toDateStr }) => {
+      triggerCsvDownload(blob, `alerts-${fromDateStr}-to-${toDateStr}.csv`);
+      onClose();
+    },
+  });
+
+  useEffect(() => {
+    if (open) {
+      setFromDate(null);
+      setToDate(null);
+      reset();
+    }
+  }, [open, reset]);
+
+  const handleConfirm = () => {
+    if (!fromDate || !toDate) return;
+    mutate({
+      fromDateStr: formatDateToApi(fromDate),
+      toDateStr: formatDateToApi(toDate),
+    });
+  };
+
+  const handleClose = () => {
+    if (isPending) return;
+    onClose();
+  };
+
+  const dateFormat = getLocalizedDateFormat(i18n.language);
+
+  return (
+    <Dialog open={open} onClose={handleClose} fullWidth maxWidth="xs">
+      <DialogTitle>{t('modal.title')}</DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={2}>
+          <Typography variant="body2">{t('modal.description')}</Typography>
+          <DatePicker
+            label={t('modal.fromDate')}
+            sx={{ width: '100%' }}
+            disableFuture
+            minDate={oneYearAgo}
+            maxDate={toDate ?? undefined}
+            value={fromDate}
+            onChange={setFromDate}
+            format={dateFormat}
+          />
+          <DatePicker
+            label={t('modal.toDate')}
+            sx={{ width: '100%' }}
+            disableFuture
+            minDate={fromDate ?? oneYearAgo}
+            value={toDate}
+            onChange={setToDate}
+            format={dateFormat}
+          />
+          {isError && (
+            <Alert severity="error" sx={{ margin: 0 }}>
+              {t('modal.errorMessage')}
+            </Alert>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} disabled={isPending}>
+          {t('modal.cancel')}
+        </Button>
+        <Button
+          onClick={handleConfirm}
+          variant="contained"
+          disabled={!fromDate || !toDate}
+          loading={isPending}
+        >
+          {t('modal.confirm')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/src/components/History/HistoryList/HistoryFilters.tsx
+++ b/src/components/History/HistoryList/HistoryFilters.tsx
@@ -1,9 +1,10 @@
+import { Stack, Typography } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import type { PickerValue } from '@mui/x-date-pickers/internals';
 import { useState } from 'react';
 
 import i18n from '@/i18n';
-import { getNowMinusOneYear } from '@/utils/dates';
+import { getLocalizedDateFormat, getNowMinusOneYear } from '@/utils/dates';
 import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
 
 import type { FiltersType } from '../../../utils/history';
@@ -13,50 +14,42 @@ interface HistoryFiltersType {
   setFilters: React.Dispatch<React.SetStateAction<FiltersType>>;
 }
 
-const getDateFormat = (locale: string) => {
-  switch (locale) {
-    case 'fr':
-    case 'es':
-      return 'dd/MM/yyyy';
-    case 'en':
-    default:
-      return 'MM/dd/yyyy';
-  }
-};
-
 export const HistoryFilters = ({ filters, setFilters }: HistoryFiltersType) => {
   const { t } = useTranslationPrefix('history');
   const oneYearAgo = getNowMinusOneYear();
   const [currentValue, setCurrentValue] = useState<PickerValue>(filters.date);
 
   return (
-    // Properly localized DatePicker thanks to DateLocalizationProvider in App.tsxs
-    <DatePicker
-      label={t('dateField')}
-      sx={{ width: '100%' }}
-      disableFuture
-      minDate={oneYearAgo}
-      value={currentValue}
-      onChange={setCurrentValue}
-      onAccept={(newValue, context) => {
-        if (context.source === 'view') {
-          // Triggers only if a date is selected with the calendar modal
-          setFilters({
-            ...filters,
-            date: newValue,
-          });
-        }
-      }}
-      slotProps={{
-        textField: {
-          onBlur: () =>
+    <Stack spacing={1}>
+      <Typography variant="h2">{t('title')}</Typography>
+      {/* Properly localized DatePicker thanks to DateLocalizationProvider in App.tsxs */}
+      <DatePicker
+        label={t('dateField')}
+        sx={{ width: '100%' }}
+        disableFuture
+        minDate={oneYearAgo}
+        value={currentValue}
+        onChange={setCurrentValue}
+        onAccept={(newValue, context) => {
+          if (context.source === 'view') {
+            // Triggers only if a date is selected with the calendar modal
             setFilters({
               ...filters,
-              date: currentValue,
-            }),
-        },
-      }}
-      format={getDateFormat(i18n.language)}
-    />
+              date: newValue,
+            });
+          }
+        }}
+        slotProps={{
+          textField: {
+            onBlur: () =>
+              setFilters({
+                ...filters,
+                date: currentValue,
+              }),
+          },
+        }}
+        format={getLocalizedDateFormat(i18n.language)}
+      />
+    </Stack>
   );
 };

--- a/src/components/History/HistoryList/HistoryList.tsx
+++ b/src/components/History/HistoryList/HistoryList.tsx
@@ -11,6 +11,7 @@ import type { AlertType } from '../../../utils/alerts';
 import { type FiltersType } from '../../../utils/history.ts';
 import { useTranslationPrefix } from '../../../utils/useTranslationPrefix';
 import { AlertsCardsColumn } from '../../Alerts/AlertsList/AlertsCardsColumn.tsx';
+import { HistoryExport } from './HistoryExport.tsx';
 import { HistoryFilters } from './HistoryFilters.tsx';
 
 interface HistoryListType {
@@ -41,8 +42,8 @@ export const HistoryList = ({
 
   return (
     <Stack bgcolor={theme.palette.customBackground.light} height="100%">
-      <Grid minHeight="55px" padding={{ xs: 1, sm: 2 }} alignContent="center">
-        <Typography variant="h2">{t('title')}</Typography>
+      <Grid padding={{ xs: 1, sm: 2 }}>
+        <HistoryExport />
       </Grid>
       <Divider orientation="horizontal" flexItem />
       <Grid padding={{ xs: 1, sm: 2 }}>

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -156,7 +156,7 @@
     "loadMoreMessage": "Weitere Alarme laden",
     "export": {
       "title": "Export",
-      "button": "CSV herunterladen",
+      "button": "Alarme exportieren",
       "modal": {
         "title": "Alarme exportieren",
         "description": "Wählen Sie einen Datumsbereich aus, um die entsprechenden Alarme als CSV-Datei herunterzuladen.",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -153,7 +153,20 @@
     "iconAlt": "Keine Warnung anzuzeigen",
     "errorFetchSequencesMessage": "Auf unserer Seite ist etwas schief gelaufen. Bitte versuchen Sie es später erneut.",
     "dateField": "Datum",
-    "loadMoreMessage": "Weitere Alarme laden"
+    "loadMoreMessage": "Weitere Alarme laden",
+    "export": {
+      "title": "Export",
+      "button": "CSV herunterladen",
+      "modal": {
+        "title": "Alarme exportieren",
+        "description": "Wählen Sie einen Datumsbereich aus, um die entsprechenden Alarme als CSV-Datei herunterzuladen.",
+        "fromDate": "Von",
+        "toDate": "Bis",
+        "cancel": "Abbrechen",
+        "confirm": "Herunterladen",
+        "errorMessage": "Beim Export ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut."
+      }
+    }
   },
   "live": {
     "errorFetchInfos": "Auf unserer Seite ist etwas schief gelaufen. Bitte versuchen Sie es später erneut.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -152,7 +152,20 @@
     "iconAlt": "No alert to display",
     "errorFetchSequencesMessage": "Something went wrong on our side. Please try again later.",
     "dateField": "Date",
-    "loadMoreMessage": "Load more alerts"
+    "loadMoreMessage": "Load more alerts",
+    "export": {
+      "title": "Export",
+      "button": "Download CSV",
+      "modal": {
+        "title": "Export alerts",
+        "description": "Select a date range to download the corresponding alerts as a CSV file.",
+        "fromDate": "From",
+        "toDate": "To",
+        "cancel": "Cancel",
+        "confirm": "Download",
+        "errorMessage": "An error occurred during the export. Please try again."
+      }
+    }
   },
   "live": {
     "errorFetchInfos": "Something went wrong on our side. Please try again later.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -155,7 +155,7 @@
     "loadMoreMessage": "Load more alerts",
     "export": {
       "title": "Export",
-      "button": "Download CSV",
+      "button": "Export alerts",
       "modal": {
         "title": "Export alerts",
         "description": "Select a date range to download the corresponding alerts as a CSV file.",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -152,7 +152,20 @@
     "iconAlt": "No hay alertas que mostrar",
     "errorFetchSequencesMessage": "Se ha producido un error. Vuelva a intentarlo más tarde.",
     "dateField": "Fecha",
-    "loadMoreMessage": "Mostrar más alertas"
+    "loadMoreMessage": "Mostrar más alertas",
+    "export": {
+      "title": "Exportar",
+      "button": "Descargar CSV",
+      "modal": {
+        "title": "Exportar alertas",
+        "description": "Seleccione un intervalo de fechas para descargar las alertas correspondientes en formato CSV.",
+        "fromDate": "Desde",
+        "toDate": "Hasta",
+        "cancel": "Cancelar",
+        "confirm": "Descargar",
+        "errorMessage": "Se ha producido un error durante la exportación. Por favor, inténtelo de nuevo."
+      }
+    }
   },
   "live": {
     "errorFetchInfos": "Se ha producido un error. Vuelva a intentarlo más tarde.",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -155,7 +155,7 @@
     "loadMoreMessage": "Mostrar más alertas",
     "export": {
       "title": "Exportar",
-      "button": "Descargar CSV",
+      "button": "Exportar alertas",
       "modal": {
         "title": "Exportar alertas",
         "description": "Seleccione un intervalo de fechas para descargar las alertas correspondientes en formato CSV.",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -155,7 +155,7 @@
     "loadMoreMessage": "Afficher plus d'alertes",
     "export": {
       "title": "Export",
-      "button": "Télécharger le CSV",
+      "button": "Exporter les alertes",
       "modal": {
         "title": "Exporter les alertes",
         "description": "Sélectionnez une plage de dates pour télécharger les alertes correspondantes au format CSV.",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -152,7 +152,20 @@
     "iconAlt": "Aucune alerte à afficher",
     "errorFetchSequencesMessage": "Une erreur inattendue est survenue. Veuillez réessayer plus tard.",
     "dateField": "Date",
-    "loadMoreMessage": "Afficher plus d'alertes"
+    "loadMoreMessage": "Afficher plus d'alertes",
+    "export": {
+      "title": "Export",
+      "button": "Télécharger le CSV",
+      "modal": {
+        "title": "Exporter les alertes",
+        "description": "Sélectionnez une plage de dates pour télécharger les alertes correspondantes au format CSV.",
+        "fromDate": "Du",
+        "toDate": "Au",
+        "cancel": "Annuler",
+        "confirm": "Télécharger",
+        "errorMessage": "Une erreur s'est produite pendant l'export. Veuillez réessayer."
+      }
+    }
   },
   "live": {
     "errorFetchInfos": "Une erreur inattendue est survenue. Veuillez réessayer plus tard.",

--- a/src/services/alerts.ts
+++ b/src/services/alerts.ts
@@ -106,6 +106,22 @@ export const getAlertsByFilters = async (
     });
 };
 
+export const exportAlerts = async (
+  fromDate: string,
+  toDate: string
+): Promise<Blob> => {
+  return apiInstance
+    .get('/api/v1/alerts/export', {
+      params: { from_date: fromDate, to_date: toDate },
+      responseType: 'blob',
+    })
+    .then((response: AxiosResponse<Blob>) => response.data)
+    .catch((err: unknown) => {
+      console.error(err);
+      throw err;
+    });
+};
+
 export const getDetectionsBySequence = async (
   sequenceId: number,
   isDesc = true

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -67,6 +67,17 @@ export const formatDateToApi = (date: DateTime) => {
   return date.toFormat('yyyy-MM-dd');
 };
 
+export const getLocalizedDateFormat = (locale: string) => {
+  switch (locale) {
+    case 'fr':
+    case 'es':
+      return 'dd/MM/yyyy';
+    case 'en':
+    default:
+      return 'MM/dd/yyyy';
+  }
+};
+
 export const formatUnixToTime = (dateNb: number) => {
   const date = unixToDatetime(dateNb);
   return date.toFormat(FORMAT_DISPLAY_TIME);


### PR DESCRIPTION
## Summary

  - Add an Export section above the History browse panel: a "Download CSV" button opens a modal with from/to date pickers (both required), calls GET /api/v1/alerts/export and triggers a CSV download via blob URL, then auto-closes.
  - New exportAlerts(fromDate, toDate) service in services/alerts.ts (axios, responseType: 'blob'); new HistoryExport + HistoryExportModal components colocated under components/History/HistoryList/.
  - Refactor: extract shared getLocalizedDateFormat helper to utils/dates.ts (deduped from HistoryFilters), restructure left panel to two h2-titled sections (Export / History) with translations added in en/fr/es/de.

### Screenshots
<img width="1512" height="788" alt="Capture d’écran 2026-05-08 à 10 54 35" src="https://github.com/user-attachments/assets/86ea5e53-58f3-4416-9bd2-80203372d287" />
<img width="1508" height="726" alt="Capture d’écran 2026-05-08 à 10 54 47" src="https://github.com/user-attachments/assets/f9d49c29-a56f-4c4a-a4e8-c98e0c6a2928" />
<img width="1320" height="978" alt="image" src="https://github.com/user-attachments/assets/a1efadc1-390a-482f-9507-5f8c56306f0a" />

