### PR TITLE
Feat/add onf layer on map

### DIFF
--- a/src/components/Common/Map/MapLayerControl.tsx
+++ b/src/components/Common/Map/MapLayerControl.tsx
@@ -21,6 +21,7 @@ import { type BaseLayerType, useMapLayers } from '@/utils/useMapLayers';
 import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
 
 import { DfciGridOverlay } from './DfciGridOverlay';
+import { OnfForestOverlay } from './OnfForestOverlay';
 
 interface LayerButtonProps {
   icon: React.ReactNode;
@@ -52,6 +53,7 @@ export const MapLayerControl = ({
   const { baseLayer, updateBaseLayer } = useMapLayers();
   const [expanded, setExpanded] = useState(false);
   const [dfciEnabled, setDfciEnabled] = useState(false);
+  const [onfForestEnabled, setOnfForestEnabled] = useState(false);
 
   const handleBaseLayerChange = (
     _: React.MouseEvent<HTMLElement>,
@@ -65,6 +67,7 @@ export const MapLayerControl = ({
   return (
     <>
       <DfciGridOverlay visible={dfciEnabled} />
+      <OnfForestOverlay visible={onfForestEnabled} />
 
       <Box
         sx={{
@@ -161,6 +164,22 @@ export const MapLayerControl = ({
                       label={
                         <Typography sx={{ m: 0 }} variant="body2">
                           {t('dfciGrid')}
+                        </Typography>
+                      }
+                    />
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          checked={onfForestEnabled}
+                          onChange={(e) =>
+                            setOnfForestEnabled(e.target.checked)
+                          }
+                          size="small"
+                        />
+                      }
+                      label={
+                        <Typography sx={{ m: 0 }} variant="body2">
+                          {t('onfForest')}
                         </Typography>
                       }
                     />

--- a/src/components/Common/Map/OnfForestOverlay.tsx
+++ b/src/components/Common/Map/OnfForestOverlay.tsx
@@ -1,0 +1,25 @@
+import { WMSTileLayer } from 'react-leaflet';
+
+import { ONF_FOREST_LAYER_CONFIG } from '@/utils/useMapLayers';
+
+interface OnfForestOverlayProps {
+  visible: boolean;
+}
+
+export const OnfForestOverlay = ({ visible }: OnfForestOverlayProps) => {
+  if (!visible) return null;
+
+  return (
+    <WMSTileLayer
+      url={ONF_FOREST_LAYER_CONFIG.url}
+      layers={ONF_FOREST_LAYER_CONFIG.layers}
+      attribution={ONF_FOREST_LAYER_CONFIG.attribution}
+      format={ONF_FOREST_LAYER_CONFIG.format}
+      transparent={ONF_FOREST_LAYER_CONFIG.transparent}
+      version={ONF_FOREST_LAYER_CONFIG.version}
+      opacity={0.6}
+      maxZoom={19}
+      maxNativeZoom={18}
+    />
+  );
+};

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -188,6 +188,7 @@
     "layerControl": "Map Layers",
     "baseLayer": "Base Layer",
     "overlays": "Overlays",
-    "dfciGrid": "DFCI Grid"
+    "dfciGrid": "DFCI Grid",
+    "onfForest": "ONF forest parcels"
   }
 }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -188,6 +188,7 @@
     "layerControl": "Capas",
     "baseLayer": "Capa base",
     "overlays": "Superposiciones",
-    "dfciGrid": "Cuadrícula DFCI"
+    "dfciGrid": "Cuadrícula DFCI",
+    "onfForest": "Parcelas forestales ONF"
   }
 }

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -190,6 +190,7 @@
     "layerControl": "Couches",
     "baseLayer": "Fond de carte",
     "overlays": "Surcouches",
-    "dfciGrid": "Carroyage DFCI"
+    "dfciGrid": "Carroyage DFCI",
+    "onfForest": "Parcelles forestières ONF"
   }
 }

--- a/src/utils/useMapLayers.ts
+++ b/src/utils/useMapLayers.ts
@@ -36,6 +36,25 @@ export const DFCI_LAYER_CONFIG: TileLayerConfig = {
   maxZoom: 18,
 };
 
+export interface WmsLayerConfig {
+  url: string;
+  layers: string;
+  attribution: string;
+  format: string;
+  transparent: boolean;
+  version: string;
+}
+
+export const ONF_FOREST_LAYER_CONFIG: WmsLayerConfig = {
+  url: 'https://data.geopf.fr/wms-v/ows',
+  layers: 'FORETS.PUBLIQUES',
+  attribution:
+    '&copy; <a href="https://www.onf.fr/">ONF</a> / <a href="https://www.ign.fr/">IGN</a>',
+  format: 'image/png',
+  transparent: true,
+  version: '1.3.0',
+};
+
 export const useMapLayers = () => {
   const { preferences, updatePreferences } = usePreferences();
 


### PR DESCRIPTION
## Summary

  - Add an optional ONF forest parcels map overlay so SDIS users can identify ONF-managed public forests when analyzing detections and camera coverage (issue #213).
  - Source: IGN Géoplateforme WMS (FORETS.PUBLIQUES), rendered via a new OnfForestOverlay component using WMSTileLayer, with maxNativeZoom=18 so the layer stays visible across the same zoom range as the base layers.
  - Toggle exposed in the existing MapLayerControl overlays section (Dashboard map), with translations added in en/fr/es.

### Screenshots
<img width="1504" height="792" alt="Capture d’écran 2026-05-08 à 11 21 21" src="https://github.com/user-attachments/assets/31d74728-be04-495c-a796-e3264a726c8e" />
<img width="1508" height="791" alt="Capture d’écran 2026-05-08 à 11 21 33" src="https://github.com/user-attachments/assets/87612fb3-0360-406e-a004-973747b3effb" />