### PR TITLE
Fix: too many errors message and loading in live streaming

### DIFF
--- a/src/components/Live/LiveContent/LiveStreamPanel.tsx
+++ b/src/components/Live/LiveContent/LiveStreamPanel.tsx
@@ -36,9 +36,14 @@ export const LiveStreamPanel = ({
   const id = camera.id;
   const { t } = useTranslationPrefix('live');
   const refVideo = useRef<HTMLVideoElement>(null);
-  const mediaMtx = useMediaMtx({ urlStreaming, refVideo, id: camera.id });
   const { addStreamingAction, isStreamingTimeout, statusStreamingVideo } =
     useActionsOnCamera();
+  const mediaMtx = useMediaMtx({
+    urlStreaming,
+    refVideo,
+    id: camera.id,
+    isStreamingTimeout,
+  });
 
   const initialMove = useMemo(
     () => getMoveToAzimuthFromAlert(camera, alert),
@@ -47,7 +52,7 @@ export const LiveStreamPanel = ({
   );
 
   const hasTemporaryError =
-    mediaMtx.state === StateStreaming.IS_STREAMING && !isStreamingTimeout;
+    mediaMtx.state === StateStreaming.TEMPORARY_ERROR && !isStreamingTimeout;
 
   const restartStreaming = () => {
     mediaMtx.restart();
@@ -98,8 +103,7 @@ export const LiveStreamPanel = ({
         <>
           {
             /* Streaming has been succesfully started with backendapi but mediamtx is not yet ready */
-            (mediaMtx.state === StateStreaming.IN_CREATION ||
-              mediaMtx.state == StateStreaming.TEMPORARY_ERROR) && (
+            mediaMtx.state === StateStreaming.IN_CREATION && (
               <Stack spacing={4}>
                 <Loader />
                 <Typography variant="body2">{t('loadingVideo')}</Typography>

--- a/src/components/Live/LiveContent/LiveStreamPanel.tsx
+++ b/src/components/Live/LiveContent/LiveStreamPanel.tsx
@@ -1,4 +1,3 @@
-import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import {
@@ -7,24 +6,19 @@ import {
   useEffect,
   useMemo,
   useRef,
-  useState,
 } from 'react';
 
 import { Loader } from '@/components/Common/Loader';
-import { STATUS_ERROR, STATUS_LOADING, STATUS_SUCCESS } from '@/services/axios';
+import { STATUS_ERROR, STATUS_SUCCESS } from '@/services/axios';
 import { type AlertType } from '@/utils/alerts';
 import type { CameraFullInfosType } from '@/utils/camera';
-import {
-  calculateHasRotation,
-  getMoveToAzimuthFromAlert,
-  SPEEDS,
-} from '@/utils/live';
+import { calculateHasRotation, getMoveToAzimuthFromAlert } from '@/utils/live';
 import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
 
 import { useActionsOnCamera } from '../context/useActionsOnCamera';
 import { StateStreaming, useMediaMtx } from '../hooks/useMediaMtx';
-import { FloatingActions } from './StreamActions/FloatingActions';
-import { QuickActions } from './StreamActions/QuickActions';
+import { RelaunchVideoButton } from './VideoStream/RelaunchVideoButton';
+import { VideoStream } from './VideoStream/VideoStream';
 
 interface LiveStreamPanelProps {
   urlStreaming: string;
@@ -39,7 +33,6 @@ export const LiveStreamPanel = ({
   setIsStreamVideoInterrupted,
   alert,
 }: LiveStreamPanelProps) => {
-  const [speedIndex, setSpeedIndex] = useState(1);
   const id = camera.id;
   const { t } = useTranslationPrefix('live');
   const refVideo = useRef<HTMLVideoElement>(null);
@@ -53,9 +46,8 @@ export const LiveStreamPanel = ({
     []
   );
 
-  const mediaMtxInterrupted =
-    mediaMtx.state === StateStreaming.WITH_ERROR ||
-    mediaMtx.state === StateStreaming.STOPPED;
+  const hasTemporaryError =
+    mediaMtx.state === StateStreaming.IS_STREAMING && !isStreamingTimeout;
 
   const restartStreaming = () => {
     mediaMtx.restart();
@@ -88,87 +80,62 @@ export const LiveStreamPanel = ({
   }, [hasRotation, initialMove, id, addStreamingAction]);
 
   useEffect(() => {
-    setIsStreamVideoInterrupted(mediaMtxInterrupted);
-  }, [mediaMtxInterrupted, setIsStreamVideoInterrupted]);
-
-  const setNextSpeed = () =>
-    setSpeedIndex((oldIndex) =>
-      oldIndex === SPEEDS.length - 1 ? 0 : oldIndex + 1
+    setIsStreamVideoInterrupted(
+      mediaMtx.state === StateStreaming.FAILED ||
+        mediaMtx.state === StateStreaming.STOPPED
     );
+  }, [mediaMtx, setIsStreamVideoInterrupted]);
 
   return (
     <Stack spacing={1} height="100%" p={2}>
-      {statusStreamingVideo === STATUS_ERROR && (
-        <Typography variant="body2">{t('errorNoStreaming')}</Typography>
-      )}
-      {!isStreamingTimeout && mediaMtx.state === StateStreaming.WITH_ERROR && (
-        <Stack spacing={4}>
-          <Loader />
-          <Typography variant="body2">{t('errorTmpMediaMtx')}</Typography>
-        </Stack>
-      )}
-      {!isStreamingTimeout && mediaMtx.state === StateStreaming.STOPPED && (
-        <Typography variant="body2">{t('errorFinalMediaMtx')}</Typography>
-      )}
-      {isStreamingTimeout && mediaMtxInterrupted && (
-        <Stack spacing={4} alignItems="center">
-          <Typography variant="body2">
-            {t('errorInteruptedMediaMtx')}
-          </Typography>
-          <div>
-            <Button variant="contained" onClick={restartStreaming}>
-              {t('relaunchStreamButton')}
-            </Button>
-          </div>
-        </Stack>
-      )}
-      {(statusStreamingVideo === STATUS_LOADING ||
-        (statusStreamingVideo === STATUS_SUCCESS &&
-          mediaMtx.state === StateStreaming.IN_CREATION)) && (
-        <Stack spacing={4}>
-          <Loader />
-          <Typography variant="body2">{t('loadingVideo')}</Typography>
-        </Stack>
-      )}
       {
-        <>
-          <div style={{ position: 'relative', flexGrow: 1 }}>
-            <video
-              ref={refVideo}
-              playsInline
-              autoPlay
-              style={{
-                background: '#1e1e1e',
-                width: '100%',
-                height: '100%',
-                display:
-                  statusStreamingVideo === STATUS_SUCCESS &&
-                  mediaMtx.state === StateStreaming.IS_STREAMING
-                    ? 'inline'
-                    : 'none',
-              }}
-            />
-            {statusStreamingVideo === STATUS_SUCCESS &&
-              mediaMtx.state === StateStreaming.IS_STREAMING && (
-                <FloatingActions
-                  cameraId={id}
-                  cameraType={camera.type}
-                  speed={SPEEDS[speedIndex].speed}
-                />
-              )}
-          </div>
-          {statusStreamingVideo === STATUS_SUCCESS &&
-            hasRotation &&
-            mediaMtx.state === StateStreaming.IS_STREAMING && (
-              <QuickActions
-                cameraId={id}
-                poses={camera.poses ?? []}
-                speedName={SPEEDS[speedIndex].name}
-                nextSpeed={setNextSpeed}
-              />
-            )}
-        </>
+        /* Streaming couldn't be started with backendapi : error with no retry */
+        statusStreamingVideo === STATUS_ERROR && (
+          <Typography variant="body2">{t('errorNoStreaming')}</Typography>
+        )
       }
+      {statusStreamingVideo === STATUS_SUCCESS && (
+        <>
+          {
+            /* Streaming has been succesfully started with backendapi but mediamtx is not yet ready */
+            (mediaMtx.state === StateStreaming.IN_CREATION ||
+              mediaMtx.state == StateStreaming.TEMPORARY_ERROR) && (
+              <Stack spacing={4}>
+                <Loader />
+                <Typography variant="body2">{t('loadingVideo')}</Typography>
+              </Stack>
+            )
+          }
+          {
+            /* Streaming has been succesfully started with backendapi but mediamtx has failed */
+            !isStreamingTimeout && mediaMtx.state === StateStreaming.FAILED && (
+              <RelaunchVideoButton
+                errorMessage={t('errorFinalMediaMtx')}
+                restartStreaming={restartStreaming}
+              />
+            )
+          }
+          {
+            /* Streaming has been succesfully started with backendapi but mediamtx is timeout */
+            isStreamingTimeout && mediaMtx.state === StateStreaming.FAILED && (
+              <RelaunchVideoButton
+                errorMessage={t('errorInteruptedMediaMtx')}
+                restartStreaming={restartStreaming}
+              />
+            )
+          }
+        </>
+      )}
+      {/* Streaming has been started with backendapi and mediamtx is connected */}
+      <VideoStream
+        ref={refVideo}
+        camera={camera}
+        hasRotation={hasRotation}
+        display={
+          statusStreamingVideo === STATUS_SUCCESS &&
+          (mediaMtx.state === StateStreaming.IS_STREAMING || hasTemporaryError)
+        }
+      />
     </Stack>
   );
 };

--- a/src/components/Live/LiveContent/StreamActions/QuickActions.tsx
+++ b/src/components/Live/LiveContent/StreamActions/QuickActions.tsx
@@ -86,7 +86,7 @@ export const QuickActions = ({
           <ButtonGroup>
             {poses
               .filter((pose) => pose.patrol_id != null)
-              .sort((p1, p2) => p1.azimuth - p2.azimuth)
+              .sort((p1, p2) => (p1.patrol_id ?? 0) - (p2.patrol_id ?? 0))
               .map((pose) => (
                 <Button
                   key={pose.id}

--- a/src/components/Live/LiveContent/VideoStream/RelaunchVideoButton.tsx
+++ b/src/components/Live/LiveContent/VideoStream/RelaunchVideoButton.tsx
@@ -1,0 +1,27 @@
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
+
+interface RelaunchVideoButtonProps {
+  errorMessage: string;
+  restartStreaming: () => void;
+}
+
+export const RelaunchVideoButton = ({
+  errorMessage,
+  restartStreaming,
+}: RelaunchVideoButtonProps) => {
+  const { t } = useTranslationPrefix('live');
+  return (
+    <Stack spacing={4} alignItems="center">
+      <Typography variant="body2">{errorMessage}</Typography>
+      <div>
+        <Button variant="contained" onClick={restartStreaming}>
+          {t('relaunchStreamButton')}
+        </Button>
+      </div>
+    </Stack>
+  );
+};

--- a/src/components/Live/LiveContent/VideoStream/VideoStream.tsx
+++ b/src/components/Live/LiveContent/VideoStream/VideoStream.tsx
@@ -1,0 +1,61 @@
+import { type Ref, useState } from 'react';
+
+import type { CameraFullInfosType } from '@/utils/camera';
+import { SPEEDS } from '@/utils/live';
+
+import { FloatingActions } from '../StreamActions/FloatingActions';
+import { QuickActions } from '../StreamActions/QuickActions';
+
+interface VideoStreamProps {
+  display: boolean;
+  camera: CameraFullInfosType;
+  hasRotation: boolean;
+  ref: Ref<HTMLVideoElement>;
+}
+
+export const VideoStream = ({
+  display,
+  camera,
+  hasRotation,
+  ref,
+}: VideoStreamProps) => {
+  const [speedIndex, setSpeedIndex] = useState(1);
+
+  const setNextSpeed = () =>
+    setSpeedIndex((oldIndex) =>
+      oldIndex === SPEEDS.length - 1 ? 0 : oldIndex + 1
+    );
+
+  return (
+    <>
+      <div style={{ position: 'relative', flexGrow: 1 }}>
+        <video
+          ref={ref}
+          playsInline
+          autoPlay
+          style={{
+            background: '#1e1e1e',
+            width: '100%',
+            height: '100%',
+            display: display ? 'inline' : 'none',
+          }}
+        />
+        {display && (
+          <FloatingActions
+            cameraId={camera.id}
+            cameraType={camera.type}
+            speed={SPEEDS[speedIndex].speed}
+          />
+        )}
+      </div>
+      {display && hasRotation && (
+        <QuickActions
+          cameraId={camera.id}
+          poses={camera.poses ?? []}
+          speedName={SPEEDS[speedIndex].name}
+          nextSpeed={setNextSpeed}
+        />
+      )}
+    </>
+  );
+};

--- a/src/components/Live/context/ActionsOnCameraProvider.tsx
+++ b/src/components/Live/context/ActionsOnCameraProvider.tsx
@@ -26,6 +26,7 @@ import {
   type StreamingAction,
 } from '../context/ActionsOnCameraContext';
 
+const MAX_RETRY_ON_ACTIONS = 3;
 const TIME_BETWEEN_START_AND_MOVE_MS = 3000;
 const LIVE_STREAMING_TIMEOUT_MS =
   appConfig.getConfig().LIVE_STREAMING_TIMEOUT_SECONDS * 1000;
@@ -48,6 +49,7 @@ export const ActionsOnCameraContextProvider: React.FC<{
 
   const { mutateAsync: startStreamingMutate, status: statusStart } =
     useMutation({
+      retry: MAX_RETRY_ON_ACTIONS,
       mutationFn: (params: {
         id: number;
         hasRotation: boolean;
@@ -72,6 +74,7 @@ export const ActionsOnCameraContextProvider: React.FC<{
     });
 
   const { mutateAsync: stopStreamingMutate, status: statusStop } = useMutation({
+    retry: MAX_RETRY_ON_ACTIONS,
     mutationFn: (params: { id: number; hasRotation: boolean }) =>
       params.hasRotation
         ? stopStreamingThenStartPatrol(params.id)

--- a/src/components/Live/hooks/reader.js
+++ b/src/components/Live/hooks/reader.js
@@ -26,7 +26,7 @@
  */
 
 const RETRY_PAUSE_IN_MS = 1000;
-const RETRY_NB_MAX = 5;
+const RETRY_NB_MAX = 20;
 
 /** WebRTC/WHEP reader. */
 export class MediaMTXWebRTCReader {

--- a/src/components/Live/hooks/reader.js
+++ b/src/components/Live/hooks/reader.js
@@ -25,8 +25,8 @@
  * @property {OnFailLoading} onFailLoading - called when there's no more call to WHEP endpoint.
  */
 
-const RETRY_PAUSE_IN_MS = 2000;
-const RETRY_NB_MAX = 20;
+const RETRY_PAUSE_IN_MS = 1000;
+const RETRY_NB_MAX = 5;
 
 /** WebRTC/WHEP reader. */
 export class MediaMTXWebRTCReader {

--- a/src/components/Live/hooks/useMediaMtx.tsx
+++ b/src/components/Live/hooks/useMediaMtx.tsx
@@ -17,16 +17,19 @@ interface StreamVideoProps {
 export const StateStreaming = {
   IN_CREATION: 0, // StartStreaming command launched, waiting for the data to arrive to the broadcast url
   IS_STREAMING: 1, // The reader is broadcasting data
-  WITH_ERROR: 2, // Temporary failure in broadcasting data
-  STOPPED: 3, // The reader has failed and will not try again de connect the broadcast url
+  TEMPORARY_ERROR: 2, // Temporary failure in broadcasting data
+  FAILED: 3, // The reader has failed loading and will not try again de connect the broadcast url
+  STOPPED: 4, // The reader is stopped and will not try again de connect the broadcast url
 };
+
+const INITIAL_STATE = StateStreaming.IN_CREATION;
 
 export const useMediaMtx = ({
   urlStreaming,
   refVideo,
   id,
 }: StreamVideoProps) => {
-  const [state, setState] = useState<number>(StateStreaming.IN_CREATION);
+  const [state, setState] = useState<number>(INITIAL_STATE);
 
   const reader = useMemo(() => {
     if (urlStreaming) {
@@ -37,13 +40,12 @@ export const useMediaMtx = ({
           setState((oldValue) =>
             // Set to error state only if the video is initialized
             oldValue === StateStreaming.IS_STREAMING
-              ? StateStreaming.WITH_ERROR
+              ? StateStreaming.TEMPORARY_ERROR
               : oldValue
           );
         },
         onTrack: (evt: RTCTrackEvent) => {
           // Signal from streaming is etablished
-
           setState(StateStreaming.IS_STREAMING);
           if (refVideo.current) {
             refVideo.current.srcObject = evt.streams[0];
@@ -51,7 +53,7 @@ export const useMediaMtx = ({
         },
         onFailLoading: () => {
           console.error('failed loading stream');
-          setState(StateStreaming.STOPPED);
+          setState(StateStreaming.FAILED);
         },
       });
     } else {
@@ -59,15 +61,17 @@ export const useMediaMtx = ({
     }
   }, [refVideo, urlStreaming]);
 
-  const restart = useCallback(() => {
-    setState(StateStreaming.IN_CREATION);
-    reader?.start();
+  const start = useCallback(() => {
+    setState(INITIAL_STATE);
+    if (reader) {
+      reader.start();
+    }
   }, [reader]);
 
   useEffect(() => {
     // Clean up reader
     if (reader && id) {
-      setState(StateStreaming.IN_CREATION);
+      setState(INITIAL_STATE);
       reader.start();
     }
     return () => {
@@ -78,5 +82,5 @@ export const useMediaMtx = ({
     };
   }, [reader, id]);
 
-  return { state, restart };
+  return { state, restart: start };
 };

--- a/src/components/Live/hooks/useMediaMtx.tsx
+++ b/src/components/Live/hooks/useMediaMtx.tsx
@@ -12,6 +12,7 @@ interface StreamVideoProps {
   urlStreaming: string;
   refVideo: RefObject<HTMLVideoElement | null>;
   id: number;
+  isStreamingTimeout: boolean;
 }
 
 export const StateStreaming = {
@@ -28,6 +29,7 @@ export const useMediaMtx = ({
   urlStreaming,
   refVideo,
   id,
+  isStreamingTimeout,
 }: StreamVideoProps) => {
   const [state, setState] = useState<number>(INITIAL_STATE);
 
@@ -37,12 +39,16 @@ export const useMediaMtx = ({
         url: urlStreaming,
         onError: (err: string) => {
           console.log(err);
-          setState((oldValue) =>
+          setState((oldValue) => {
             // Set to error state only if the video is initialized
-            oldValue === StateStreaming.IS_STREAMING
-              ? StateStreaming.TEMPORARY_ERROR
-              : oldValue
-          );
+            if (oldValue === StateStreaming.IN_CREATION) {
+              return StateStreaming.IN_CREATION;
+            } else {
+              return isStreamingTimeout
+                ? StateStreaming.FAILED
+                : StateStreaming.TEMPORARY_ERROR;
+            }
+          });
         },
         onTrack: (evt: RTCTrackEvent) => {
           // Signal from streaming is etablished
@@ -59,9 +65,9 @@ export const useMediaMtx = ({
     } else {
       return null;
     }
-  }, [refVideo, urlStreaming]);
+  }, [isStreamingTimeout, refVideo, urlStreaming]);
 
-  const start = useCallback(() => {
+  const restart = useCallback(() => {
     setState(INITIAL_STATE);
     if (reader) {
       reader.start();
@@ -82,5 +88,5 @@ export const useMediaMtx = ({
     };
   }, [reader, id]);
 
-  return { state, restart: start };
+  return { state, restart };
 };

--- a/src/services/live.ts
+++ b/src/services/live.ts
@@ -127,7 +127,6 @@ export const moveCamera = async (
   return apiInstance
     .post(`/api/v1/cameras/${cameraId}/control/move`, null, {
       params: {
-        camera_ip: cameraId,
         direction,
         speed,
         pose_id: poseId,


### PR DESCRIPTION
- [REAFCTO] Create two new components to reduce code in LiveStreamPanel
- [FIX] Sort azimuth by patrol_id (Fix #215)
- [FIX]Add retry in "Start streaming" and "stop streaming" api calls
- [FIX] Clarify differents cases in LiveStreamPanel : 
     - Add comment on each case
     - Use isStreamingTimeout (after 2mins of streaming) to quickly tag an error as Temporary or Final
     - Update mediamtx to seperate states : 
         - Before: "stopped" if no more network calls, "with error" if retry is still working on
         - After : "stopped" if voluntary no more network calls, "failed" if no more network calls because of error, "temporary error" if retry is still working on
      
