### PR TITLE
fix background color of PYRONEAR text to fit the rest of the page

### DIFF
--- a/src/components/Alerts/PyronearForestWatch.tsx
+++ b/src/components/Alerts/PyronearForestWatch.tsx
@@ -409,9 +409,6 @@ export const PyronearForestWatch = ({
           </g>
         </g>
 
-        {/* White band under the scene for the wordmark */}
-        <rect x="0" y="440" width="680" height="60" fill="#ffffff" />
-
         {/* Pyronear logo */}
         <g transform="translate(340 210) scale(1.15) translate(-340 -210)">
           <path


### PR DESCRIPTION
## BEFORE

<img width="2392" height="1517" alt="image" src="https://github.com/user-attachments/assets/fdf35d57-ccdf-4769-9a3d-dd9c6595a5c2" />

(bottom part here is not clean)

## AFTER

<img width="2387" height="1515" alt="image" src="https://github.com/user-attachments/assets/e2b54557-ec29-4598-bdc1-ab946039b7e8" />
