### PR TITLE
fix: reset livestream state when switching cameras

### DIFF
--- a/src/components/Live/LiveContainer.tsx
+++ b/src/components/Live/LiveContainer.tsx
@@ -49,6 +49,7 @@ export const LiveContainer = ({
   const isCameraSelected = !!selectedSite && !!selectedCamera;
 
   const changeCamera = (newSite: SiteType, newCameraId: number | null) => {
+    setIsStreamVideoInterrupted(false);
     setSelectedSite(newSite);
     setSelectedCameraId(newCameraId ?? getDefaultCameraIdBySite(newSite));
   };
@@ -114,6 +115,7 @@ export const LiveContainer = ({
           <Grid container spacing={2} flexGrow={1}>
             <Grid size={8}>
               <LiveStreamPanel
+                key={`${selectedSite.id}-${selectedCamera.id}`}
                 urlStreaming={urlStreaming}
                 setIsStreamVideoInterrupted={setIsStreamVideoInterrupted}
                 camera={selectedCamera}


### PR DESCRIPTION
## Summary
- Reset the interrupted livestream flag when users switch site/camera
- Remount the stream panel per selected site-camera pair so intentional stream cleanup is not shown as a failure

Fixes #148

## Local checks
- pnpm run format:check
- pnpm lint
- pnpm build

Note: local full test runs hit the existing macOS EMFILE issue while importing MUI icon modules; GitHub Actions is the authoritative test run.