### PR TITLE
fix: show alerts menu badge for unlabeled alerts

### DIFF
--- a/src/components/Topbar/DesktopTopbar.tsx
+++ b/src/components/Topbar/DesktopTopbar.tsx
@@ -9,11 +9,13 @@ import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
 import { NavigationLink } from './NavigationLink';
 import LanguageSwitcher from './Preferences/LanguageSwitcher';
 import { PreferencesButton } from './Preferences/PreferencesButton';
+import { useAlertsMenuBadge } from './useAlertsMenuBadge';
 
 export const DesktopTopbar = () => {
   const { t } = useTranslationPrefix('pages');
   const { token } = useAuth();
   const isLoggedIn = !!token;
+  const hasUnlabelledAlerts = useAlertsMenuBadge(isLoggedIn);
 
   return (
     <>
@@ -32,7 +34,11 @@ export const DesktopTopbar = () => {
               </Link>
               {isLoggedIn && (
                 <Stack direction="row" spacing={2}>
-                  <NavigationLink path="/alerts" label={t('alerts')} />
+                  <NavigationLink
+                    path="/alerts"
+                    label={t('alerts')}
+                    hasBadge={hasUnlabelledAlerts}
+                  />
                   <NavigationLink path="/dashboard" label={t('dashboard')} />
                   <NavigationLink path="/history" label={t('history')} />
                 </Stack>

--- a/src/components/Topbar/DesktopTopbar.tsx
+++ b/src/components/Topbar/DesktopTopbar.tsx
@@ -41,6 +41,7 @@ export const DesktopTopbar = () => {
                   <NavigationLink
                     path="/alerts"
                     label={t('alerts')}
+                    badgeContent={unlabelledAlertsCount}
                     badgeLabel={alertsBadgeLabel}
                   />
                   <NavigationLink path="/dashboard" label={t('dashboard')} />

--- a/src/components/Topbar/DesktopTopbar.tsx
+++ b/src/components/Topbar/DesktopTopbar.tsx
@@ -15,7 +15,11 @@ export const DesktopTopbar = () => {
   const { t } = useTranslationPrefix('pages');
   const { token } = useAuth();
   const isLoggedIn = !!token;
-  const hasUnlabelledAlerts = useAlertsMenuBadge(isLoggedIn);
+  const unlabelledAlertsCount = useAlertsMenuBadge(isLoggedIn);
+  const alertsBadgeLabel =
+    unlabelledAlertsCount > 0
+      ? t('unlabeledAlertsBadge', { count: unlabelledAlertsCount })
+      : undefined;
 
   return (
     <>
@@ -37,7 +41,7 @@ export const DesktopTopbar = () => {
                   <NavigationLink
                     path="/alerts"
                     label={t('alerts')}
-                    hasBadge={hasUnlabelledAlerts}
+                    badgeLabel={alertsBadgeLabel}
                   />
                   <NavigationLink path="/dashboard" label={t('dashboard')} />
                   <NavigationLink path="/history" label={t('history')} />

--- a/src/components/Topbar/MobileTopbar.tsx
+++ b/src/components/Topbar/MobileTopbar.tsx
@@ -19,7 +19,7 @@ import { useAlertsMenuBadge } from './useAlertsMenuBadge';
 export const MobileTopbar = () => {
   const { token } = useAuth();
   const isLoggedIn = !!token;
-  const hasUnlabelledAlerts = useAlertsMenuBadge(isLoggedIn);
+  const unlabelledAlertsCount = useAlertsMenuBadge(isLoggedIn);
 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const handleDrawerClose = () => {
@@ -61,7 +61,7 @@ export const MobileTopbar = () => {
       <MobileTopbarDrawer
         isOpen={isDrawerOpen}
         handleClose={handleDrawerClose}
-        hasUnlabelledAlerts={hasUnlabelledAlerts}
+        unlabelledAlertsCount={unlabelledAlertsCount}
       />
     </>
   );

--- a/src/components/Topbar/MobileTopbar.tsx
+++ b/src/components/Topbar/MobileTopbar.tsx
@@ -14,10 +14,12 @@ import { useAuth } from '@/context/useAuth';
 import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
 
 import { MobileTopbarDrawer } from './MobileTopbarDrawer';
+import { useAlertsMenuBadge } from './useAlertsMenuBadge';
 
 export const MobileTopbar = () => {
   const { token } = useAuth();
   const isLoggedIn = !!token;
+  const hasUnlabelledAlerts = useAlertsMenuBadge(isLoggedIn);
 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const handleDrawerClose = () => {
@@ -59,6 +61,7 @@ export const MobileTopbar = () => {
       <MobileTopbarDrawer
         isOpen={isDrawerOpen}
         handleClose={handleDrawerClose}
+        hasUnlabelledAlerts={hasUnlabelledAlerts}
       />
     </>
   );

--- a/src/components/Topbar/MobileTopbar.tsx
+++ b/src/components/Topbar/MobileTopbar.tsx
@@ -1,6 +1,7 @@
 import MenuIcon from '@mui/icons-material/Menu';
 import {
   AppBar,
+  Badge,
   IconButton,
   Slide,
   Stack,
@@ -38,17 +39,38 @@ export const MobileTopbar = () => {
           <Toolbar disableGutters>
             <Stack flexGrow={1} direction="row" paddingX="1rem">
               {isLoggedIn && (
-                <IconButton
-                  edge="start"
-                  color="inherit"
-                  aria-label={t('menuLabel')}
-                  size="small"
-                  onClick={() => {
-                    setIsDrawerOpen(true);
+                /* The drawer is closed by default, so the count has to reach
+                   the button that opens it to be of any use. */
+                <Badge
+                  badgeContent={unlabelledAlertsCount}
+                  color="error"
+                  invisible={!unlabelledAlertsCount}
+                  sx={{
+                    '& .MuiBadge-badge': {
+                      fontWeight: 700,
+                      right: 2,
+                      top: 2,
+                    },
                   }}
                 >
-                  <MenuIcon />
-                </IconButton>
+                  <IconButton
+                    edge="start"
+                    color="inherit"
+                    aria-label={
+                      unlabelledAlertsCount > 0
+                        ? t('menuLabelWithAlerts', {
+                            count: unlabelledAlertsCount,
+                          })
+                        : t('menuLabel')
+                    }
+                    size="small"
+                    onClick={() => {
+                      setIsDrawerOpen(true);
+                    }}
+                  >
+                    <MenuIcon />
+                  </IconButton>
+                </Badge>
               )}
               <img height="30px" src={logo} alt="Logo" />
             </Stack>

--- a/src/components/Topbar/MobileTopbarDrawer.tsx
+++ b/src/components/Topbar/MobileTopbarDrawer.tsx
@@ -40,6 +40,7 @@ export const MobileTopbarDrawer = ({
               <NavigationLink
                 path="/alerts"
                 label={t('alerts')}
+                badgeContent={unlabelledAlertsCount}
                 badgeLabel={alertsBadgeLabel}
               />
             </ListItem>

--- a/src/components/Topbar/MobileTopbarDrawer.tsx
+++ b/src/components/Topbar/MobileTopbarDrawer.tsx
@@ -8,17 +8,21 @@ import { NavigationLink } from './NavigationLink';
 import LanguageSwitcher from './Preferences/LanguageSwitcher';
 
 interface MobileTopbarDrawerProps {
-  hasUnlabelledAlerts: boolean;
+  unlabelledAlertsCount: number;
   isOpen: boolean;
   handleClose: () => void;
 }
 
 export const MobileTopbarDrawer = ({
-  hasUnlabelledAlerts,
+  unlabelledAlertsCount,
   isOpen,
   handleClose,
 }: MobileTopbarDrawerProps) => {
   const { t } = useTranslationPrefix('pages');
+  const alertsBadgeLabel =
+    unlabelledAlertsCount > 0
+      ? t('unlabeledAlertsBadge', { count: unlabelledAlertsCount })
+      : undefined;
 
   return (
     <Drawer open={isOpen} onClose={handleClose} onClick={handleClose}>
@@ -36,7 +40,7 @@ export const MobileTopbarDrawer = ({
               <NavigationLink
                 path="/alerts"
                 label={t('alerts')}
-                hasBadge={hasUnlabelledAlerts}
+                badgeLabel={alertsBadgeLabel}
               />
             </ListItem>
             <ListItem>

--- a/src/components/Topbar/MobileTopbarDrawer.tsx
+++ b/src/components/Topbar/MobileTopbarDrawer.tsx
@@ -8,11 +8,13 @@ import { NavigationLink } from './NavigationLink';
 import LanguageSwitcher from './Preferences/LanguageSwitcher';
 
 interface MobileTopbarDrawerProps {
+  hasUnlabelledAlerts: boolean;
   isOpen: boolean;
   handleClose: () => void;
 }
 
 export const MobileTopbarDrawer = ({
+  hasUnlabelledAlerts,
   isOpen,
   handleClose,
 }: MobileTopbarDrawerProps) => {
@@ -31,7 +33,11 @@ export const MobileTopbarDrawer = ({
           <Divider sx={{ margin: 0 }} />
           <List>
             <ListItem>
-              <NavigationLink path="/alerts" label={t('alerts')} />
+              <NavigationLink
+                path="/alerts"
+                label={t('alerts')}
+                hasBadge={hasUnlabelledAlerts}
+              />
             </ListItem>
             <ListItem>
               <NavigationLink path="/dashboard" label={t('dashboard')} />

--- a/src/components/Topbar/NavigationLink.tsx
+++ b/src/components/Topbar/NavigationLink.tsx
@@ -17,7 +17,7 @@ export const NavigationLink = ({
     <NavLink to={path} style={{ textDecoration: 'none' }}>
       {/* This style above prevents the default underline from the html tag <a> */}
       {({ isActive }) => (
-        <Stack alignItems="center" spacing={0.25}>
+        <Stack direction="row" alignItems="center" spacing={0.75}>
           <Typography
             color={theme.palette.primary.contrastText}
             sx={{

--- a/src/components/Topbar/NavigationLink.tsx
+++ b/src/components/Topbar/NavigationLink.tsx
@@ -1,33 +1,49 @@
-import { Typography, useTheme } from '@mui/material';
+import { Badge, Typography, useTheme } from '@mui/material';
 import { NavLink } from 'react-router-dom';
 
 interface NavigationLinkProps {
+  hasBadge?: boolean;
   path: string;
   label: string;
 }
 
-export const NavigationLink = ({ path, label }: NavigationLinkProps) => {
+export const NavigationLink = ({
+  hasBadge = false,
+  path,
+  label,
+}: NavigationLinkProps) => {
   const theme = useTheme();
   return (
     <NavLink to={path} style={{ textDecoration: 'none' }}>
       {/* This style above prevents the default underline from the html tag <a> */}
       {({ isActive }) => (
-        <Typography
-          color={theme.palette.primary.contrastText}
-          sx={{
-            ...(isActive
-              ? {
-                  fontWeight: 500,
-                  backgroundColor: theme.palette.primary.light,
-                  borderRadius: 1,
-                }
-              : {}),
-            padding: 1,
-            fontSize: '1.2rem',
+        <Badge
+          color="error"
+          invisible={!hasBadge}
+          variant="dot"
+          overlap="rectangular"
+          anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'right',
           }}
         >
-          {label}
-        </Typography>
+          <Typography
+            color={theme.palette.primary.contrastText}
+            sx={{
+              ...(isActive
+                ? {
+                    fontWeight: 500,
+                    backgroundColor: theme.palette.primary.light,
+                    borderRadius: 1,
+                  }
+                : {}),
+              padding: 1,
+              fontSize: '1.2rem',
+            }}
+          >
+            {label}
+          </Typography>
+        </Badge>
       )}
     </NavLink>
   );

--- a/src/components/Topbar/NavigationLink.tsx
+++ b/src/components/Topbar/NavigationLink.tsx
@@ -1,14 +1,14 @@
-import { Badge, Typography, useTheme } from '@mui/material';
+import { Chip, Stack, Typography, useTheme } from '@mui/material';
 import { NavLink } from 'react-router-dom';
 
 interface NavigationLinkProps {
-  hasBadge?: boolean;
+  badgeLabel?: string;
   path: string;
   label: string;
 }
 
 export const NavigationLink = ({
-  hasBadge = false,
+  badgeLabel,
   path,
   label,
 }: NavigationLinkProps) => {
@@ -17,16 +17,7 @@ export const NavigationLink = ({
     <NavLink to={path} style={{ textDecoration: 'none' }}>
       {/* This style above prevents the default underline from the html tag <a> */}
       {({ isActive }) => (
-        <Badge
-          color="error"
-          invisible={!hasBadge}
-          variant="dot"
-          overlap="rectangular"
-          anchorOrigin={{
-            vertical: 'top',
-            horizontal: 'right',
-          }}
-        >
+        <Stack alignItems="center" spacing={0.25}>
           <Typography
             color={theme.palette.primary.contrastText}
             sx={{
@@ -43,7 +34,19 @@ export const NavigationLink = ({
           >
             {label}
           </Typography>
-        </Badge>
+          {badgeLabel && (
+            <Chip
+              color="error"
+              label={badgeLabel}
+              size="small"
+              sx={{
+                height: 18,
+                fontSize: '0.65rem',
+                fontWeight: 700,
+              }}
+            />
+          )}
+        </Stack>
       )}
     </NavLink>
   );

--- a/src/components/Topbar/NavigationLink.tsx
+++ b/src/components/Topbar/NavigationLink.tsx
@@ -1,13 +1,15 @@
-import { Chip, Stack, Typography, useTheme } from '@mui/material';
+import { Badge, Typography, useTheme } from '@mui/material';
 import { NavLink } from 'react-router-dom';
 
 interface NavigationLinkProps {
+  badgeContent?: number;
   badgeLabel?: string;
   path: string;
   label: string;
 }
 
 export const NavigationLink = ({
+  badgeContent,
   badgeLabel,
   path,
   label,
@@ -17,7 +19,20 @@ export const NavigationLink = ({
     <NavLink to={path} style={{ textDecoration: 'none' }}>
       {/* This style above prevents the default underline from the html tag <a> */}
       {({ isActive }) => (
-        <Stack direction="row" alignItems="center" spacing={0.75}>
+        <Badge
+          badgeContent={badgeContent}
+          color="error"
+          invisible={!badgeContent}
+          title={badgeLabel}
+          aria-label={badgeLabel}
+          sx={{
+            '& .MuiBadge-badge': {
+              fontWeight: 700,
+              right: 4,
+              top: 6,
+            },
+          }}
+        >
           <Typography
             color={theme.palette.primary.contrastText}
             sx={{
@@ -28,25 +43,14 @@ export const NavigationLink = ({
                     borderRadius: 1,
                   }
                 : {}),
-              padding: 1,
               fontSize: '1.2rem',
+              px: badgeContent ? 2.25 : 1,
+              py: 1,
             }}
           >
             {label}
           </Typography>
-          {badgeLabel && (
-            <Chip
-              color="error"
-              label={badgeLabel}
-              size="small"
-              sx={{
-                height: 18,
-                fontSize: '0.65rem',
-                fontWeight: 700,
-              }}
-            />
-          )}
-        </Stack>
+        </Badge>
       )}
     </NavLink>
   );

--- a/src/components/Topbar/Topbar.test.tsx
+++ b/src/components/Topbar/Topbar.test.tsx
@@ -1,16 +1,29 @@
 import { fireEvent, screen } from '@testing-library/react';
+import { DateTime } from 'luxon';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { AlertTypeApi } from '../../services/alerts';
 import { renderWithProviders } from '../../test/renderWithProviders';
 import { Topbar } from './Topbar';
 
 let isMobileMock = false;
+let unlabelledAlertsMock: AlertTypeApi[] = [];
 
 vi.mock('@mui/material', async () => {
   const actual = await vi.importActual('@mui/material');
   return {
     ...actual,
     useMediaQuery: () => isMobileMock,
+  };
+});
+
+vi.mock('../../services/alerts', async () => {
+  const actual = await vi.importActual<typeof import('../../services/alerts')>(
+    '../../services/alerts'
+  );
+  return {
+    ...actual,
+    getUnlabelledLatestAlerts: () => Promise.resolve(unlabelledAlertsMock),
   };
 });
 
@@ -27,6 +40,7 @@ vi.mock('../../utils/useTranslationPrefix', () => ({
 describe('Topbar', () => {
   beforeEach(() => {
     isMobileMock = false;
+    unlabelledAlertsMock = [];
   });
 
   afterEach(() => {
@@ -52,6 +66,17 @@ describe('Topbar', () => {
     expect(screen.queryByText('dashboard')).toBeInTheDocument();
   });
 
+  it('shows the unlabelled alerts count on the mobile menu button', async () => {
+    isMobileMock = true;
+    unlabelledAlertsMock = [alertStartedNow(1), alertStartedNow(2)];
+    renderWithProviders(<Topbar />);
+
+    expect(
+      await screen.findByLabelText('menuLabelWithAlerts')
+    ).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
   it('renders preferences button on desktop', () => {
     isMobileMock = false;
     renderWithProviders(<Topbar />);
@@ -70,4 +95,14 @@ describe('Topbar', () => {
 
     expect(screen.getByRole('menu')).toBeInTheDocument();
   });
+});
+
+const alertStartedNow = (id: number): AlertTypeApi => ({
+  id,
+  started_at: DateTime.utc().toISO({ includeOffset: false }),
+  sequences: [],
+  organization_id: 0,
+  lat: null,
+  lon: null,
+  last_seen_at: '',
 });

--- a/src/components/Topbar/useAlertsMenuBadge.ts
+++ b/src/components/Topbar/useAlertsMenuBadge.ts
@@ -1,5 +1,4 @@
 import { useQuery } from '@tanstack/react-query';
-import { useLocation } from 'react-router-dom';
 
 import {
   getUnlabelledLatestAlerts,
@@ -11,18 +10,14 @@ const ALERTS_LIST_REFRESH_INTERVAL_SECONDS =
   appConfig.getConfig().ALERTS_LIST_REFRESH_INTERVAL_SECONDS;
 
 export const useAlertsMenuBadge = (enabled: boolean) => {
-  const { pathname } = useLocation();
-  const isAlertsPage = pathname === '/alerts';
-  const shouldFetchAlerts = enabled && !isAlertsPage;
-
   const { data: alertList } = useQuery({
     queryKey: UNLABELLED_ALERTS_QUERY_KEY,
     queryFn: getUnlabelledLatestAlerts,
-    enabled: shouldFetchAlerts,
-    refetchInterval: shouldFetchAlerts
+    enabled,
+    refetchInterval: enabled
       ? ALERTS_LIST_REFRESH_INTERVAL_SECONDS * 1000
       : false,
   });
 
-  return shouldFetchAlerts ? (alertList?.length ?? 0) : 0;
+  return enabled ? (alertList?.length ?? 0) : 0;
 };

--- a/src/components/Topbar/useAlertsMenuBadge.ts
+++ b/src/components/Topbar/useAlertsMenuBadge.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+import { useLocation } from 'react-router-dom';
+
+import {
+  getUnlabelledLatestAlerts,
+  UNLABELLED_ALERTS_QUERY_KEY,
+} from '@/services/alerts';
+import appConfig from '@/services/appConfig';
+
+const ALERTS_LIST_REFRESH_INTERVAL_SECONDS =
+  appConfig.getConfig().ALERTS_LIST_REFRESH_INTERVAL_SECONDS;
+
+export const useAlertsMenuBadge = (enabled: boolean) => {
+  const { pathname } = useLocation();
+  const isAlertsPage = pathname === '/alerts';
+  const shouldFetchAlerts = enabled && !isAlertsPage;
+
+  const { data: alertList } = useQuery({
+    queryKey: UNLABELLED_ALERTS_QUERY_KEY,
+    queryFn: getUnlabelledLatestAlerts,
+    enabled: shouldFetchAlerts,
+    refetchInterval: shouldFetchAlerts
+      ? ALERTS_LIST_REFRESH_INTERVAL_SECONDS * 1000
+      : false,
+  });
+
+  return shouldFetchAlerts && (alertList?.length ?? 0) > 0;
+};

--- a/src/components/Topbar/useAlertsMenuBadge.ts
+++ b/src/components/Topbar/useAlertsMenuBadge.ts
@@ -5,6 +5,7 @@ import {
   UNLABELLED_ALERTS_QUERY_KEY,
 } from '@/services/alerts';
 import appConfig from '@/services/appConfig';
+import { isDateToday } from '@/utils/dates';
 
 const ALERTS_LIST_REFRESH_INTERVAL_SECONDS =
   appConfig.getConfig().ALERTS_LIST_REFRESH_INTERVAL_SECONDS;
@@ -14,10 +15,9 @@ export const useAlertsMenuBadge = (enabled: boolean) => {
     queryKey: UNLABELLED_ALERTS_QUERY_KEY,
     queryFn: getUnlabelledLatestAlerts,
     enabled,
-    refetchInterval: enabled
-      ? ALERTS_LIST_REFRESH_INTERVAL_SECONDS * 1000
-      : false,
+    refetchInterval: ALERTS_LIST_REFRESH_INTERVAL_SECONDS * 1000,
   });
 
-  return enabled ? (alertList?.length ?? 0) : 0;
+  return (alertList ?? []).filter((alert) => isDateToday(alert.started_at))
+    .length;
 };

--- a/src/components/Topbar/useAlertsMenuBadge.ts
+++ b/src/components/Topbar/useAlertsMenuBadge.ts
@@ -24,5 +24,5 @@ export const useAlertsMenuBadge = (enabled: boolean) => {
       : false,
   });
 
-  return shouldFetchAlerts && (alertList?.length ?? 0) > 0;
+  return shouldFetchAlerts ? (alertList?.length ?? 0) : 0;
 };

--- a/src/components/Topbar/useAlertsMenuBadge.ts
+++ b/src/components/Topbar/useAlertsMenuBadge.ts
@@ -4,18 +4,13 @@ import {
   getUnlabelledLatestAlerts,
   UNLABELLED_ALERTS_QUERY_KEY,
 } from '@/services/alerts';
-import appConfig from '@/services/appConfig';
 import { isDateToday } from '@/utils/dates';
-
-const ALERTS_LIST_REFRESH_INTERVAL_SECONDS =
-  appConfig.getConfig().ALERTS_LIST_REFRESH_INTERVAL_SECONDS;
 
 export const useAlertsMenuBadge = (enabled: boolean) => {
   const { data: alertList } = useQuery({
     queryKey: UNLABELLED_ALERTS_QUERY_KEY,
     queryFn: getUnlabelledLatestAlerts,
     enabled,
-    refetchInterval: ALERTS_LIST_REFRESH_INTERVAL_SECONDS * 1000,
   });
 
   return (alertList ?? []).filter((alert) => isDateToday(alert.started_at))

--- a/src/context/AuthProvider.tsx
+++ b/src/context/AuthProvider.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query';
 import React, { useCallback, useMemo, useState } from 'react';
 
 import { getToken } from '../services/auth';
@@ -27,23 +28,33 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     return existingToken;
   });
 
+  /*
+   * Every cached response is scoped to the organization of the account that
+   * fetched it, so it must not outlive that account's session: observers held
+   * outside the protected routes keep their queries alive past logout, and
+   * would otherwise serve the previous user's alerts to the next one.
+   */
+  const queryClient = useQueryClient();
+
   const login = useCallback(
     async (username: string, password: string) => {
       const { token } = await getToken(username, password);
       apiInstance.defaults.headers.common.Authorization = `Bearer ${token}`;
+      queryClient.clear();
       setAuthToken(token);
       setAuthUsername(username);
       setToken(token);
       setUsername(username);
     },
-    [setToken]
+    [setToken, queryClient]
   );
 
   const logout = useCallback(() => {
+    queryClient.clear();
     clearAuthToken();
     clearAuthUsername();
     setToken(null);
-  }, [setToken]);
+  }, [setToken, queryClient]);
 
   const contextValue = useMemo(
     () => ({ token, login, logout, username }),

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -17,7 +17,8 @@
   "pages": {
     "dashboard": "Kamera-Dashboard",
     "alerts": "Live-Alarme",
-    "history": "Alarmverlauf"
+    "history": "Alarmverlauf",
+    "unlabeledAlertsBadge": "{{count}} unbeschriftet"
   },
   "topbar": {
     "menuLabel": "Menü"

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -21,7 +21,8 @@
     "unlabeledAlertsBadge": "{{count}} unbeschriftet"
   },
   "topbar": {
-    "menuLabel": "Menü"
+    "menuLabel": "Menü",
+    "menuLabelWithAlerts": "Menü, {{count}} unbeschriftet"
   },
   "common": {
     "lastUpdate": "Letzte Aktualisierung:"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -17,7 +17,8 @@
   "pages": {
     "dashboard": "Camera dashboard",
     "alerts": "Live alerts",
-    "history": "History alerts"
+    "history": "History alerts",
+    "unlabeledAlertsBadge": "{{count}} unlabeled"
   },
   "topbar": {
     "menuLabel": "Menu"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -21,7 +21,8 @@
     "unlabeledAlertsBadge": "{{count}} unlabeled"
   },
   "topbar": {
-    "menuLabel": "Menu"
+    "menuLabel": "Menu",
+    "menuLabelWithAlerts": "Menu, {{count}} unlabeled"
   },
   "common": {
     "lastUpdate": "Last update:"

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -17,7 +17,8 @@
   "pages": {
     "dashboard": "Panel de cámaras",
     "alerts": "Alertas en vivo",
-    "history": "Histórico de alertas"
+    "history": "Histórico de alertas",
+    "unlabeledAlertsBadge": "{{count}} sin etiquetar"
   },
   "topbar": {
     "menuLabel": "Menú"

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -21,7 +21,8 @@
     "unlabeledAlertsBadge": "{{count}} sin etiquetar"
   },
   "topbar": {
-    "menuLabel": "Menú"
+    "menuLabel": "Menú",
+    "menuLabelWithAlerts": "Menú, {{count}} sin etiquetar"
   },
   "common": {
     "lastUpdate": "Última actualización:"

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -17,7 +17,8 @@
   "pages": {
     "dashboard": "Caméras",
     "alerts": "Alertes en cours",
-    "history": "Historique des alertes"
+    "history": "Historique des alertes",
+    "unlabeledAlertsBadge": "{{count}} à étiqueter"
   },
   "topbar": {
     "menuLabel": "Menu"

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -21,7 +21,8 @@
     "unlabeledAlertsBadge": "{{count}} à étiqueter"
   },
   "topbar": {
-    "menuLabel": "Menu"
+    "menuLabel": "Menu",
+    "menuLabelWithAlerts": "Menu, {{count}} à étiqueter"
   },
   "common": {
     "lastUpdate": "Dernière mise à jour :"

--- a/src/test/TestProviders.tsx
+++ b/src/test/TestProviders.tsx
@@ -1,4 +1,5 @@
 import { ThemeProvider } from '@mui/material';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 
@@ -11,14 +12,24 @@ interface ProvidersProps {
 }
 
 const TestProviders = ({ children }: ProvidersProps) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
   return (
-    <AuthProvider>
-      <PreferencesProvider>
-        <BrowserRouter>
-          <ThemeProvider theme={theme}>{children}</ThemeProvider>
-        </BrowserRouter>
-      </PreferencesProvider>
-    </AuthProvider>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <PreferencesProvider>
+          <BrowserRouter>
+            <ThemeProvider theme={theme}>{children}</ThemeProvider>
+          </BrowserRouter>
+        </PreferencesProvider>
+      </AuthProvider>
+    </QueryClientProvider>
   );
 };
 


### PR DESCRIPTION
## Summary
- Add a compact count chip beside the Alerts navigation item when unlabeled alerts exist
- Keep the chip visible across pages, including `/alerts`, until all unlabeled alerts are labeled
- Reuse the existing unlabelled alerts React Query cache/key

Fixes #198

## Local checks
- pnpm run format:check
- pnpm lint
- pnpm build

Note: targeted Vitest for Topbar still hits the existing local macOS EMFILE issue while importing MUI icon modules before tests execute.