### PR TITLE
fix: highlight selected alert sequence on map

### DIFF
--- a/src/components/Alerts/AlertDetails/AlertInfos/AlertInfos.tsx
+++ b/src/components/Alerts/AlertDetails/AlertInfos/AlertInfos.tsx
@@ -55,7 +55,7 @@ export const AlertInfos = ({
         >
           <AlertInfosSections sequence={sequence} alert={alert} />
           <Grid container flexGrow={1} minHeight={200}>
-            <AlertMap alert={alert} />
+            <AlertMap alert={alert} selectedSequence={sequence} />
           </Grid>
           <AlertActionButtons
             sequence={sequence}

--- a/src/components/Alerts/AlertDetails/AlertInfos/AlertInfos.tsx
+++ b/src/components/Alerts/AlertDetails/AlertInfos/AlertInfos.tsx
@@ -55,7 +55,7 @@ export const AlertInfos = ({
         >
           <AlertInfosSections sequence={sequence} alert={alert} />
           <Grid container flexGrow={1} minHeight={200}>
-            <AlertMap alert={alert} selectedSequence={sequence} />
+            <AlertMap alert={alert} selectedSequenceId={sequence.id} />
           </Grid>
           <AlertActionButtons
             sequence={sequence}

--- a/src/components/Alerts/AlertDetails/AlertInfos/AlertMap.tsx
+++ b/src/components/Alerts/AlertDetails/AlertInfos/AlertMap.tsx
@@ -13,6 +13,7 @@ import { buildVisionPolygon, DEFAULT_CAM_RANGE_KM } from '@/utils/cameraVision';
 
 interface AlertMap {
   alert: AlertType;
+  selectedSequence: SequenceWithCameraInfoType;
   height?: number | string;
 }
 
@@ -20,7 +21,7 @@ type SequenceWithCamera = SequenceWithCameraInfoType & {
   camera: NonNullable<SequenceWithCameraInfoType['camera']>;
 };
 
-const AlertMap = ({ alert, height = '100%' }: AlertMap) => {
+const AlertMap = ({ alert, selectedSequence, height = '100%' }: AlertMap) => {
   const [fullScreen, setFullScreen] = useState(false);
 
   useEffect(() => {
@@ -83,6 +84,7 @@ const AlertMap = ({ alert, height = '100%' }: AlertMap) => {
         {sequencesWithPolygons.map((sequence) => (
           <Fragment key={sequence.id}>
             <SequencePolygon
+              isHighlighted={sequence.id === selectedSequence.id}
               visionPolygonPoints={sequence.visionPolygonPoints}
             />
             <CameraMarker camera={sequence.camera} />

--- a/src/components/Alerts/AlertDetails/AlertInfos/AlertMap.tsx
+++ b/src/components/Alerts/AlertDetails/AlertInfos/AlertMap.tsx
@@ -13,7 +13,7 @@ import { buildVisionPolygon, DEFAULT_CAM_RANGE_KM } from '@/utils/cameraVision';
 
 interface AlertMap {
   alert: AlertType;
-  selectedSequence: SequenceWithCameraInfoType;
+  selectedSequenceId: number;
   height?: number | string;
 }
 
@@ -21,7 +21,7 @@ type SequenceWithCamera = SequenceWithCameraInfoType & {
   camera: NonNullable<SequenceWithCameraInfoType['camera']>;
 };
 
-const AlertMap = ({ alert, selectedSequence, height = '100%' }: AlertMap) => {
+const AlertMap = ({ alert, selectedSequenceId, height = '100%' }: AlertMap) => {
   const [fullScreen, setFullScreen] = useState(false);
 
   useEffect(() => {
@@ -84,7 +84,7 @@ const AlertMap = ({ alert, selectedSequence, height = '100%' }: AlertMap) => {
         {sequencesWithPolygons.map((sequence) => (
           <Fragment key={sequence.id}>
             <SequencePolygon
-              isHighlighted={sequence.id === selectedSequence.id}
+              isHighlighted={sequence.id === selectedSequenceId}
               visionPolygonPoints={sequence.visionPolygonPoints}
             />
             <CameraMarker camera={sequence.camera} />

--- a/src/components/Common/Map/SequencePolygon.tsx
+++ b/src/components/Common/Map/SequencePolygon.tsx
@@ -17,9 +17,9 @@ export const SequencePolygon = ({
       positions={visionPolygonPoints}
       pathOptions={{
         color: theme.palette.error.main,
-        opacity: isHighlighted ? 0.9 : 0.2,
+        opacity: isHighlighted ? 0.9 : 0.45,
         fillColor: theme.palette.error.main,
-        fillOpacity: isHighlighted ? 0.35 : 0.08,
+        fillOpacity: isHighlighted ? 0.35 : 0.15,
         weight: isHighlighted ? 4 : 2,
       }}
     />

--- a/src/components/Common/Map/SequencePolygon.tsx
+++ b/src/components/Common/Map/SequencePolygon.tsx
@@ -3,10 +3,12 @@ import type { LatLng } from 'leaflet';
 import { Polygon } from 'react-leaflet';
 
 interface CameraViewPolygonProps {
+  isHighlighted?: boolean;
   visionPolygonPoints: LatLng[];
 }
 
 export const SequencePolygon = ({
+  isHighlighted = true,
   visionPolygonPoints,
 }: CameraViewPolygonProps) => {
   const theme = useTheme();
@@ -15,10 +17,10 @@ export const SequencePolygon = ({
       positions={visionPolygonPoints}
       pathOptions={{
         color: theme.palette.error.main,
-        opacity: 0.5,
+        opacity: isHighlighted ? 0.9 : 0.2,
         fillColor: theme.palette.error.main,
-        fillOpacity: 0.2,
-        weight: 3,
+        fillOpacity: isHighlighted ? 0.35 : 0.08,
+        weight: isHighlighted ? 4 : 2,
       }}
     />
   );


### PR DESCRIPTION
## Summary
- Pass the currently selected sequence into the alert detail map
- Emphasize the selected sequence cone with stronger opacity/weight
- Dim non-selected sequence cones so triangulated alerts are easier to read

Fixes #152

## Local checks
- pnpm run format:check
- pnpm lint
- pnpm build