### PR TITLE
Fix #199: filter alerts by local calendar day

### DIFF
--- a/src/pages/AlertsPage.tsx
+++ b/src/pages/AlertsPage.tsx
@@ -6,8 +6,11 @@ import { getUnlabelledLatestAlerts } from '@/services/alerts';
 import appConfig from '@/services/appConfig';
 import { STATUS_ERROR, STATUS_LOADING, STATUS_SUCCESS } from '@/services/axios';
 import { getCameraList } from '@/services/camera';
-import { type AlertType, mapListAlertApiToAlertType } from '@/utils/alerts';
-import { isDateToday } from '@/utils/dates';
+import {
+  type AlertType,
+  filterAlertsStartedToday,
+  mapListAlertApiToAlertType,
+} from '@/utils/alerts';
 import { useDetectNewSequences as useDetectNewAlerts } from '@/utils/useDetectNewSequences';
 
 const ALERTS_LIST_REFRESH_INTERVAL_SECONDS =
@@ -32,7 +35,7 @@ export const AlertsPage = () => {
   });
 
   const todayAlerts = useMemo(
-    () => (alertList ?? []).filter((alert) => isDateToday(alert.started_at)),
+    () => filterAlertsStartedToday(alertList ?? []),
     [alertList]
   );
 

--- a/src/utils/alerts.test.ts
+++ b/src/utils/alerts.test.ts
@@ -1,6 +1,7 @@
 import {
   type AlertType,
   extractCameraListFromAlert,
+  filterAlertsStartedToday,
   formatAzimuth,
   formatPosition,
   hasNewAlertSince,
@@ -165,5 +166,67 @@ describe('hasNewSequenceSince', () => {
       1740476223000
     ); //2025-02-25T09:37:03
     expect(result).toBeTruthy();
+  });
+});
+
+describe('filterAlertsStartedToday', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should exclude previous-day alerts even if they are within the last 24 hours', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-02-26T10:00:00.000Z'));
+
+    const result = filterAlertsStartedToday([
+      {
+        id: 1,
+        started_at: '2025-02-25T22:30:00',
+        sequences: [],
+        organization_id: 0,
+        lat: null,
+        lon: null,
+        last_seen_at: '',
+      },
+      {
+        id: 2,
+        started_at: '2025-02-26T08:30:00',
+        sequences: [],
+        organization_id: 0,
+        lat: null,
+        lon: null,
+        last_seen_at: '',
+      },
+    ]);
+
+    expect(result.map((alert) => alert.id)).toStrictEqual([2]);
+  });
+
+  it('should use the local calendar day when filtering UTC alert timestamps', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-02-25T23:30:00.000Z'));
+
+    const result = filterAlertsStartedToday([
+      {
+        id: 1,
+        started_at: '2025-02-25T22:30:00',
+        sequences: [],
+        organization_id: 0,
+        lat: null,
+        lon: null,
+        last_seen_at: '',
+      },
+      {
+        id: 2,
+        started_at: '2025-02-25T23:30:00',
+        sequences: [],
+        organization_id: 0,
+        lat: null,
+        lon: null,
+        last_seen_at: '',
+      },
+    ]);
+
+    expect(result.map((alert) => alert.id)).toStrictEqual([2]);
   });
 });

--- a/src/utils/alerts.ts
+++ b/src/utils/alerts.ts
@@ -2,7 +2,7 @@ import { DateTime } from 'luxon';
 
 import type { AlertTypeApi, SequenceTypeApi } from '../services/alerts';
 import type { CameraType } from '../services/camera';
-import { convertIsoToUnix } from './dates';
+import { convertIsoToUnix, isDateToday } from './dates';
 
 export interface AlertType {
   id: number;
@@ -66,6 +66,9 @@ export const mapListAlertApiToAlertType = (
     mapOneAlertApiToAlertType(alertDto, camerasList)
   );
 };
+
+export const filterAlertsStartedToday = (alertListDto: AlertTypeApi[]) =>
+  alertListDto.filter((alertDto) => isDateToday(alertDto.started_at));
 
 export const countUnlabelledSequences = (
   sequences: SequenceWithCameraInfoType[]


### PR DESCRIPTION
## Summary
- Move the Alerts page current-day filtering into an explicit alert utility
- Keep only alerts whose started_at timestamp falls on the user's local calendar day
- Add tests for rolling-24h edge cases and UTC-to-local day boundaries

Fixes #199

## Local checks
- pnpm test src/utils/alerts.test.ts -- --runInBand
- pnpm run format:check
- pnpm lint
- pnpm build

Note: full pnpm test was attempted locally; it hit the known macOS EMFILE/ENFILE limit while importing MUI icons after 96 tests had passed.