### PR TITLE
Fix #202: load all unlabeled alerts on Alerts page

### DIFF
--- a/src/pages/AlertsPage.tsx
+++ b/src/pages/AlertsPage.tsx
@@ -1,5 +1,9 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useMemo } from 'react';
+import {
+  useInfiniteQuery,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo } from 'react';
 
 import { AlertsContainer } from '@/components/Alerts/AlertsContainer';
 import { getUnlabelledLatestAlerts } from '@/services/alerts';
@@ -12,6 +16,7 @@ import { useDetectNewSequences as useDetectNewAlerts } from '@/utils/useDetectNe
 
 const ALERTS_LIST_REFRESH_INTERVAL_SECONDS =
   appConfig.getConfig().ALERTS_LIST_REFRESH_INTERVAL_SECONDS;
+const UNLABELLED_ALERTS_PAGE_SIZE = 100;
 
 export const AlertsPage = () => {
   const queryClient = useQueryClient();
@@ -19,10 +24,22 @@ export const AlertsPage = () => {
     isFetching,
     dataUpdatedAt,
     status: statusSequences,
-    data: alertList,
-  } = useQuery({
+    data: alertPages,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useInfiniteQuery({
     queryKey: ['unlabelledAlerts'],
-    queryFn: getUnlabelledLatestAlerts,
+    queryFn: async ({ pageParam }) =>
+      await getUnlabelledLatestAlerts(
+        UNLABELLED_ALERTS_PAGE_SIZE,
+        pageParam * UNLABELLED_ALERTS_PAGE_SIZE
+      ),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, _allPages, lastPageParam) =>
+      lastPage.length === UNLABELLED_ALERTS_PAGE_SIZE
+        ? lastPageParam + 1
+        : undefined,
     refetchInterval: ALERTS_LIST_REFRESH_INTERVAL_SECONDS * 1000,
   });
 
@@ -31,8 +48,16 @@ export const AlertsPage = () => {
     queryFn: getCameraList,
   });
 
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
+    }
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  const alertList = useMemo(() => alertPages?.pages.flat() ?? [], [alertPages]);
+
   const todayAlerts = useMemo(
-    () => (alertList ?? []).filter((alert) => isDateToday(alert.started_at)),
+    () => alertList.filter((alert) => isDateToday(alert.started_at)),
     [alertList]
   );
 

--- a/src/services/alerts.test.ts
+++ b/src/services/alerts.test.ts
@@ -1,0 +1,29 @@
+import { getUnlabelledLatestAlerts } from './alerts';
+
+const mockGet = vi.hoisted(() => vi.fn());
+
+vi.mock('./axios', () => ({
+  apiInstance: {
+    get: mockGet,
+  },
+}));
+
+describe('alerts service', () => {
+  beforeEach(() => {
+    mockGet.mockResolvedValue({ data: [] });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getUnlabelledLatestAlerts', () => {
+    it('should pass pagination parameters to the API', async () => {
+      await getUnlabelledLatestAlerts(100, 200);
+
+      expect(mockGet).toHaveBeenCalledWith('/api/v1/alerts/unlabeled/latest', {
+        params: { limit: 100, offset: 200 },
+      });
+    });
+  });
+});

--- a/src/services/alerts.ts
+++ b/src/services/alerts.ts
@@ -63,9 +63,12 @@ export const getAlertById = async (
     });
 };
 
-export const getUnlabelledLatestAlerts = async (): Promise<AlertTypeApi[]> => {
+export const getUnlabelledLatestAlerts = async (
+  limit?: number,
+  offset?: number
+): Promise<AlertTypeApi[]> => {
   return apiInstance
-    .get('/api/v1/alerts/unlabeled/latest')
+    .get('/api/v1/alerts/unlabeled/latest', { params: { limit, offset } })
     .then((response: AxiosResponse) => {
       try {
         const result = apiAlertListResponseSchema.safeParse(response.data);


### PR DESCRIPTION
## Summary
- Use the paginated unlabeled alerts endpoint from the Alerts page
- Automatically fetch additional pages until the endpoint is exhausted
- Flatten all loaded pages before applying the existing current-day filter
- Add a service test that verifies limit/offset are sent to the API

Fixes #202

## Local checks
- pnpm test src/services/alerts.test.ts src/utils/alerts.test.ts -- --runInBand
- pnpm run format:check
- pnpm lint
- pnpm build

Note: full pnpm test was attempted locally; it hit the known macOS EMFILE/ENFILE limit while importing MUI icons after 95 tests had passed.