### PR TITLE
Feat #119: add History CSV export

### DIFF
--- a/src/components/History/HistoryList/HistoryExportCsv.tsx
+++ b/src/components/History/HistoryList/HistoryExportCsv.tsx
@@ -1,0 +1,143 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { DateTime } from 'luxon';
+import { useMemo, useState } from 'react';
+
+import i18n from '@/i18n';
+import { exportAlertsCsv } from '@/services/alerts';
+import { getDateFormat } from '@/utils/dateFormat';
+import { formatDateToApi, getNowMinusOneYear } from '@/utils/dates';
+import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
+
+const triggerCsvDownload = (
+  blob: Blob,
+  filename: string,
+  documentRef: Document = document
+) => {
+  const url = URL.createObjectURL(blob);
+  const link = documentRef.createElement('a');
+  link.href = url;
+  link.download = filename;
+  documentRef.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+};
+
+export const HistoryExportCsv = () => {
+  const { t } = useTranslationPrefix('history.export');
+  const oneYearAgo = getNowMinusOneYear();
+  const [isOpen, setIsOpen] = useState(false);
+  const [fromDate, setFromDate] = useState<DateTime | null>(null);
+  const [toDate, setToDate] = useState<DateTime | null>(null);
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [hasError, setHasError] = useState(false);
+
+  const isDateRangeInvalid = useMemo(
+    () => !!fromDate && !!toDate && toDate < fromDate,
+    [fromDate, toDate]
+  );
+
+  const isDownloadDisabled =
+    !fromDate || !toDate || isDateRangeInvalid || isDownloading;
+
+  const handleClose = () => {
+    if (!isDownloading) {
+      setIsOpen(false);
+      setHasError(false);
+    }
+  };
+
+  const handleDownload = async () => {
+    if (!fromDate || !toDate || isDateRangeInvalid) {
+      return;
+    }
+
+    setIsDownloading(true);
+    setHasError(false);
+
+    const formattedFromDate = formatDateToApi(fromDate);
+    const formattedToDate = formatDateToApi(toDate);
+
+    try {
+      const response = await exportAlertsCsv(
+        formattedFromDate,
+        formattedToDate
+      );
+
+      triggerCsvDownload(
+        response.data,
+        `alerts_${formattedFromDate}_${formattedToDate}.csv`
+      );
+      setIsOpen(false);
+    } catch {
+      setHasError(true);
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  return (
+    <>
+      <Stack spacing={1}>
+        <Typography variant="h3">{t('title')}</Typography>
+        <Typography variant="subtitle2">{t('description')}</Typography>
+        <Button variant="outlined" onClick={() => setIsOpen(true)}>
+          {t('button')}
+        </Button>
+      </Stack>
+      <Dialog open={isOpen} onClose={handleClose} maxWidth="xs" fullWidth>
+        <DialogTitle>{t('modalTitle')}</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} pt={1}>
+            <Typography variant="subtitle1">{t('modalDescription')}</Typography>
+            <DatePicker
+              label={t('fromDateField')}
+              disableFuture
+              minDate={oneYearAgo}
+              maxDate={toDate ?? undefined}
+              value={fromDate}
+              onChange={setFromDate}
+              format={getDateFormat(i18n.language)}
+            />
+            <DatePicker
+              label={t('toDateField')}
+              disableFuture
+              minDate={fromDate ?? oneYearAgo}
+              value={toDate}
+              onChange={setToDate}
+              format={getDateFormat(i18n.language)}
+            />
+            {isDateRangeInvalid && (
+              <Typography color="error">{t('dateRangeError')}</Typography>
+            )}
+            {hasError && (
+              <Typography color="error">{t('downloadError')}</Typography>
+            )}
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} disabled={isDownloading}>
+            {t('cancelButton')}
+          </Button>
+          <Button
+            variant="contained"
+            onClick={() => void handleDownload()}
+            loading={isDownloading}
+            disabled={isDownloadDisabled}
+          >
+            {t('downloadButton')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};

--- a/src/components/History/HistoryList/HistoryFilters.tsx
+++ b/src/components/History/HistoryList/HistoryFilters.tsx
@@ -3,6 +3,7 @@ import type { PickerValue } from '@mui/x-date-pickers/internals';
 import { useState } from 'react';
 
 import i18n from '@/i18n';
+import { getDateFormat } from '@/utils/dateFormat';
 import { getNowMinusOneYear } from '@/utils/dates';
 import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
 
@@ -12,17 +13,6 @@ interface HistoryFiltersType {
   filters: FiltersType;
   setFilters: React.Dispatch<React.SetStateAction<FiltersType>>;
 }
-
-const getDateFormat = (locale: string) => {
-  switch (locale) {
-    case 'fr':
-    case 'es':
-      return 'dd/MM/yyyy';
-    case 'en':
-    default:
-      return 'MM/dd/yyyy';
-  }
-};
 
 export const HistoryFilters = ({ filters, setFilters }: HistoryFiltersType) => {
   const { t } = useTranslationPrefix('history');

--- a/src/components/History/HistoryList/HistoryList.tsx
+++ b/src/components/History/HistoryList/HistoryList.tsx
@@ -11,6 +11,7 @@ import type { AlertType } from '../../../utils/alerts';
 import { type FiltersType } from '../../../utils/history.ts';
 import { useTranslationPrefix } from '../../../utils/useTranslationPrefix';
 import { AlertsCardsColumn } from '../../Alerts/AlertsList/AlertsCardsColumn.tsx';
+import { HistoryExportCsv } from './HistoryExportCsv.tsx';
 import { HistoryFilters } from './HistoryFilters.tsx';
 
 interface HistoryListType {
@@ -43,6 +44,10 @@ export const HistoryList = ({
     <Stack bgcolor={theme.palette.customBackground.light} height="100%">
       <Grid minHeight="55px" padding={{ xs: 1, sm: 2 }} alignContent="center">
         <Typography variant="h2">{t('title')}</Typography>
+      </Grid>
+      <Divider orientation="horizontal" flexItem />
+      <Grid padding={{ xs: 1, sm: 2 }}>
+        <HistoryExportCsv />
       </Grid>
       <Divider orientation="horizontal" flexItem />
       <Grid padding={{ xs: 1, sm: 2 }}>

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -153,7 +153,20 @@
     "iconAlt": "Keine Warnung anzuzeigen",
     "errorFetchSequencesMessage": "Auf unserer Seite ist etwas schief gelaufen. Bitte versuchen Sie es später erneut.",
     "dateField": "Datum",
-    "loadMoreMessage": "Weitere Alarme laden"
+    "loadMoreMessage": "Weitere Alarme laden",
+    "export": {
+      "title": "Alarme exportieren",
+      "description": "Alarme und Sequenzen für einen ausgewählten Zeitraum herunterladen.",
+      "button": "CSV exportieren",
+      "modalTitle": "Alarme als CSV exportieren",
+      "modalDescription": "Wählen Sie ein Start- und Enddatum. Der CSV-Download startet nach der Bestätigung.",
+      "fromDateField": "Startdatum",
+      "toDateField": "Enddatum",
+      "dateRangeError": "Das Enddatum muss am oder nach dem Startdatum liegen.",
+      "downloadError": "Der Export konnte nicht heruntergeladen werden. Bitte versuchen Sie es erneut.",
+      "cancelButton": "Abbrechen",
+      "downloadButton": "CSV herunterladen"
+    }
   },
   "live": {
     "errorFetchInfos": "Auf unserer Seite ist etwas schief gelaufen. Bitte versuchen Sie es später erneut.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -152,7 +152,20 @@
     "iconAlt": "No alert to display",
     "errorFetchSequencesMessage": "Something went wrong on our side. Please try again later.",
     "dateField": "Date",
-    "loadMoreMessage": "Load more alerts"
+    "loadMoreMessage": "Load more alerts",
+    "export": {
+      "title": "Export alerts",
+      "description": "Download alerts and sequences for a selected period.",
+      "button": "Export CSV",
+      "modalTitle": "Export alerts as CSV",
+      "modalDescription": "Choose a start and end date. The CSV download starts automatically after confirmation.",
+      "fromDateField": "From date",
+      "toDateField": "To date",
+      "dateRangeError": "The end date must be on or after the start date.",
+      "downloadError": "The export could not be downloaded. Please try again.",
+      "cancelButton": "Cancel",
+      "downloadButton": "Download CSV"
+    }
   },
   "live": {
     "errorFetchInfos": "Something went wrong on our side. Please try again later.",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -152,7 +152,20 @@
     "iconAlt": "No hay alertas que mostrar",
     "errorFetchSequencesMessage": "Se ha producido un error. Vuelva a intentarlo más tarde.",
     "dateField": "Fecha",
-    "loadMoreMessage": "Mostrar más alertas"
+    "loadMoreMessage": "Mostrar más alertas",
+    "export": {
+      "title": "Exportar alertas",
+      "description": "Descargar alertas y secuencias para un periodo seleccionado.",
+      "button": "Exportar CSV",
+      "modalTitle": "Exportar alertas como CSV",
+      "modalDescription": "Elija una fecha de inicio y una fecha de fin. La descarga del CSV comienza tras confirmar.",
+      "fromDateField": "Fecha de inicio",
+      "toDateField": "Fecha de fin",
+      "dateRangeError": "La fecha de fin debe ser igual o posterior a la fecha de inicio.",
+      "downloadError": "No se pudo descargar la exportación. Inténtelo de nuevo.",
+      "cancelButton": "Cancelar",
+      "downloadButton": "Descargar CSV"
+    }
   },
   "live": {
     "errorFetchInfos": "Se ha producido un error. Vuelva a intentarlo más tarde.",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -152,7 +152,20 @@
     "iconAlt": "Aucune alerte à afficher",
     "errorFetchSequencesMessage": "Une erreur inattendue est survenue. Veuillez réessayer plus tard.",
     "dateField": "Date",
-    "loadMoreMessage": "Afficher plus d'alertes"
+    "loadMoreMessage": "Afficher plus d'alertes",
+    "export": {
+      "title": "Exporter les alertes",
+      "description": "Télécharger les alertes et séquences pour une période donnée.",
+      "button": "Exporter CSV",
+      "modalTitle": "Exporter les alertes en CSV",
+      "modalDescription": "Choisissez une date de début et une date de fin. Le téléchargement du CSV démarre après validation.",
+      "fromDateField": "Date de début",
+      "toDateField": "Date de fin",
+      "dateRangeError": "La date de fin doit être postérieure ou égale à la date de début.",
+      "downloadError": "L'export n'a pas pu être téléchargé. Veuillez réessayer.",
+      "cancelButton": "Annuler",
+      "downloadButton": "Télécharger le CSV"
+    }
   },
   "live": {
     "errorFetchInfos": "Une erreur inattendue est survenue. Veuillez réessayer plus tard.",

--- a/src/services/alerts.test.ts
+++ b/src/services/alerts.test.ts
@@ -27,6 +27,7 @@ describe('alerts service', () => {
           to_date: '2026-05-03',
         },
         responseType: 'blob',
+        timeout: 30000,
       });
     });
   });

--- a/src/services/alerts.test.ts
+++ b/src/services/alerts.test.ts
@@ -1,0 +1,33 @@
+import { exportAlertsCsv } from './alerts';
+
+const mockGet = vi.hoisted(() => vi.fn());
+
+vi.mock('./axios', () => ({
+  apiInstance: {
+    get: mockGet,
+  },
+}));
+
+describe('alerts service', () => {
+  beforeEach(() => {
+    mockGet.mockResolvedValue({ data: new Blob() });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('exportAlertsCsv', () => {
+    it('should call the export endpoint with date range params', async () => {
+      await exportAlertsCsv('2026-05-01', '2026-05-03');
+
+      expect(mockGet).toHaveBeenCalledWith('/api/v1/alerts/export', {
+        params: {
+          from_date: '2026-05-01',
+          to_date: '2026-05-03',
+        },
+        responseType: 'blob',
+      });
+    });
+  });
+});

--- a/src/services/alerts.ts
+++ b/src/services/alerts.ts
@@ -106,6 +106,24 @@ export const getAlertsByFilters = async (
     });
 };
 
+export const exportAlertsCsv = async (
+  fromDate: string,
+  toDate: string
+): Promise<AxiosResponse<Blob>> => {
+  return apiInstance
+    .get<Blob>('/api/v1/alerts/export', {
+      params: {
+        from_date: fromDate,
+        to_date: toDate,
+      },
+      responseType: 'blob',
+    })
+    .catch((err: unknown) => {
+      console.error(err);
+      throw err;
+    });
+};
+
 export const getDetectionsBySequence = async (
   sequenceId: number,
   isDesc = true

--- a/src/services/alerts.ts
+++ b/src/services/alerts.ts
@@ -43,6 +43,7 @@ const apiAlertListResponseSchema = z.array(apiAlertResponseSchema);
 
 export type DetectionType = z.infer<typeof apiDetectionResponseSchema>;
 const apiDetectionListResponseSchema = z.array(apiDetectionResponseSchema);
+const ALERTS_EXPORT_TIMEOUT_MS = 30000;
 
 export const getAlertById = async (
   alertId: number
@@ -117,6 +118,7 @@ export const exportAlertsCsv = async (
         to_date: toDate,
       },
       responseType: 'blob',
+      timeout: ALERTS_EXPORT_TIMEOUT_MS,
     })
     .catch((err: unknown) => {
       console.error(err);

--- a/src/utils/dateFormat.ts
+++ b/src/utils/dateFormat.ts
@@ -1,0 +1,10 @@
+export const getDateFormat = (locale: string) => {
+  switch (locale) {
+    case 'fr':
+    case 'es':
+      return 'dd/MM/yyyy';
+    case 'en':
+    default:
+      return 'MM/dd/yyyy';
+  }
+};


### PR DESCRIPTION
## Summary
- Add an Export alerts section above the History browse controls
- Add a modal with required from/to date pickers
- Call GET /api/v1/alerts/export with the selected date range and trigger CSV download
- Add localized copy for the new export UI
- Add a focused service test for the export endpoint contract

Fixes #119

## Local checks
- pnpm test src/services/alerts.test.ts -- --runInBand
- pnpm run format:check
- pnpm lint
- pnpm build

Note: full pnpm test was attempted locally; it hit the known macOS EMFILE/ENFILE limit while importing MUI icons after 95 tests had passed.