### PR TITLE
ci: configure pnpm dependency cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,10 @@ jobs:
         with:
           node-version: ${{ vars.NODE_VERSION }}
           cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build app
         run: pnpm build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,9 +26,10 @@ jobs:
         with:
           node-version: ${{ vars.NODE_VERSION }}
           cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run format check on modified files
         run: pnpm run format:check


### PR DESCRIPTION
## Summary
- Explicitly key the pnpm `setup-node` cache from `pnpm-lock.yaml`
- Use `pnpm install --frozen-lockfile` in CI for reproducible dependency installs

Fixes #165

## Local checks
- `pnpm exec prettier .github/workflows/tests.yml .github/workflows/build.yml --check`
- `git diff --check`