### PR TITLE
fix: logout when auth token expires

### DIFF
--- a/src/components/Login/LoginForm.tsx
+++ b/src/components/Login/LoginForm.tsx
@@ -1,5 +1,6 @@
 import { Visibility, VisibilityOff } from '@mui/icons-material';
 import {
+  Alert,
   Box,
   Button,
   IconButton,
@@ -16,7 +17,7 @@ import { LoginError } from '../../services/auth';
 import { useTranslationPrefix } from '../../utils/useTranslationPrefix';
 
 const LoginForm = () => {
-  const { login } = useAuth();
+  const { clearExpiredSession, hasExpiredSession, login } = useAuth();
   const { t } = useTranslationPrefix('login');
 
   const [username, setUsername] = useState('');
@@ -41,6 +42,7 @@ const LoginForm = () => {
 
   const handleSubmit = async () => {
     try {
+      clearExpiredSession();
       await login(username, password);
       await navigate('dashboard');
     } catch (e) {
@@ -59,6 +61,11 @@ const LoginForm = () => {
       minHeight="100%"
     >
       <Paper sx={{ p: 4, width: 400 }}>
+        {hasExpiredSession && (
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            {t('sessionExpired')}
+          </Alert>
+        )}
         <form action={handleSubmit}>
           <TextField
             label={t('username')}

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -3,6 +3,8 @@ import { createContext } from 'react';
 interface AuthContextType {
   token: string | null;
   username: string | null;
+  hasExpiredSession: boolean;
+  clearExpiredSession: () => void;
   login: (username: string, password: string) => Promise<void>;
   logout: () => void;
 }

--- a/src/context/AuthProvider.test.tsx
+++ b/src/context/AuthProvider.test.tsx
@@ -1,0 +1,62 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { AxiosError, type AxiosResponse } from 'axios';
+import type { ReactNode } from 'react';
+
+import { apiInstance } from '@/services/axios';
+import { getAuthToken, setAuthToken, setAuthUsername } from '@/utils/authToken';
+
+import { AuthProvider } from './AuthProvider';
+import { useAuth } from './useAuth';
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <AuthProvider>{children}</AuthProvider>
+);
+
+describe('AuthProvider', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    delete apiInstance.defaults.headers.common.Authorization;
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    delete apiInstance.defaults.headers.common.Authorization;
+  });
+
+  it('logs out and marks the session as expired when an authenticated request returns an auth error', async () => {
+    setAuthToken('expired-token');
+    setAuthUsername('test-user');
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    const unauthorizedResponse = {
+      status: 406,
+      statusText: 'Not Acceptable',
+      data: null,
+      headers: {},
+      config: {},
+    } as AxiosResponse;
+    const unauthorizedError = new AxiosError(
+      'Invalid token',
+      undefined,
+      undefined,
+      undefined,
+      unauthorizedResponse
+    );
+
+    await act(async () => {
+      await expect(
+        apiInstance.get('/protected', {
+          adapter: () => Promise.reject(unauthorizedError),
+        })
+      ).rejects.toThrow('Invalid token');
+    });
+
+    await waitFor(() => {
+      expect(result.current.token).toBeNull();
+    });
+    expect(result.current.username).toBeNull();
+    expect(result.current.hasExpiredSession).toBe(true);
+    expect(getAuthToken()).toBeNull();
+  });
+});

--- a/src/context/AuthProvider.tsx
+++ b/src/context/AuthProvider.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import { AxiosError } from 'axios';
+import React, { useCallback, useLayoutEffect, useMemo, useState } from 'react';
 
 import { getToken } from '../services/auth';
 import { apiInstance } from '../services/axios';
@@ -12,12 +13,15 @@ import {
 } from '../utils/authToken';
 import { AuthContext } from './AuthContext';
 
+const SESSION_EXPIRED_STATUSES = new Set([401, 406]);
+
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const [username, setUsername] = useState<string | null>(() => {
     return getAuthUsername();
   });
+  const [hasExpiredSession, setHasExpiredSession] = useState(false);
   const [token, setToken] = useState<string | null>(() => {
     const existingToken = getAuthToken();
     if (existingToken) {
@@ -33,6 +37,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       apiInstance.defaults.headers.common.Authorization = `Bearer ${token}`;
       setAuthToken(token);
       setAuthUsername(username);
+      setHasExpiredSession(false);
       setToken(token);
       setUsername(username);
     },
@@ -42,12 +47,58 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   const logout = useCallback(() => {
     clearAuthToken();
     clearAuthUsername();
+    delete apiInstance.defaults.headers.common.Authorization;
+    setHasExpiredSession(false);
     setToken(null);
+    setUsername(null);
   }, [setToken]);
 
+  const expireSession = useCallback(() => {
+    clearAuthToken();
+    clearAuthUsername();
+    delete apiInstance.defaults.headers.common.Authorization;
+    setHasExpiredSession(true);
+    setToken(null);
+    setUsername(null);
+  }, []);
+
+  const clearExpiredSession = useCallback(() => {
+    setHasExpiredSession(false);
+  }, []);
+
+  useLayoutEffect(() => {
+    const interceptorId = apiInstance.interceptors.response.use(
+      (response) => response,
+      (error: unknown) => {
+        if (
+          token &&
+          error instanceof AxiosError &&
+          SESSION_EXPIRED_STATUSES.has(error.response?.status ?? 0)
+        ) {
+          expireSession();
+        }
+
+        return Promise.reject(
+          error instanceof Error ? error : new Error('API request failed')
+        );
+      }
+    );
+
+    return () => {
+      apiInstance.interceptors.response.eject(interceptorId);
+    };
+  }, [expireSession, token]);
+
   const contextValue = useMemo(
-    () => ({ token, login, logout, username }),
-    [token, login, logout, username]
+    () => ({
+      token,
+      login,
+      logout,
+      username,
+      hasExpiredSession,
+      clearExpiredSession,
+    }),
+    [token, login, logout, username, hasExpiredSession, clearExpiredSession]
   );
 
   return <AuthContext value={contextValue}>{children}</AuthContext>;

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -7,6 +7,7 @@
     "showPassword": "Passwort anzeigen",
     "hidePassword": "Passwort verbergen",
     "logout": "Abmelden",
+    "sessionExpired": "Ihre Sitzung ist abgelaufen. Bitte melden Sie sich erneut an.",
     "errors": {
       "INVALID_CREDENTIALS": "Ungültiger Benutzername oder Passwort.",
       "SERVER_ERROR": "Auf unserer Seite ist etwas schief gelaufen. Bitte versuchen Sie es später erneut.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -7,6 +7,7 @@
     "showPassword": "Show password",
     "hidePassword": "Hide password",
     "logout": "Logout",
+    "sessionExpired": "Your session has expired. Please log in again.",
     "errors": {
       "INVALID_CREDENTIALS": "Invalid username or password.",
       "SERVER_ERROR": "Something went wrong on our side. Please try again later.",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -7,6 +7,7 @@
     "showPassword": "Mostrar contraseña",
     "hidePassword": "Ocultar contraseña",
     "logout": "Desconectarse",
+    "sessionExpired": "Su sesión ha expirado. Vuelva a iniciar sesión.",
     "errors": {
       "INVALID_CREDENTIALS": "Nombre de usuario y/o contraseña incorrectos.",
       "SERVER_ERROR": "Se ha producido un error. Vuelva a intentarlo más tarde.",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -7,6 +7,7 @@
     "showPassword": "Afficher le mot de passe",
     "hidePassword": "Cacher le mot de passe",
     "logout": "Se déconnecter",
+    "sessionExpired": "Votre session a expiré. Veuillez vous reconnecter.",
     "errors": {
       "INVALID_CREDENTIALS": "Nom d'utilisateur ou mot de passe incorrect.",
       "SERVER_ERROR": "Une erreur inattendue est survenue. Veuillez réessayer plus tard.",


### PR DESCRIPTION
## Summary
- Clear stored auth state and remove the Authorization header when an authenticated API request returns an expired/invalid token response
- Redirect users through the existing protected-route flow and show a session-expired warning on the login page
- Add localized session-expired copy and a regression test for auth-error logout

Fixes #11

## Local checks
- `pnpm test src/context/AuthProvider.test.tsx -- --runInBand`
- `pnpm exec eslint src/context/AuthProvider.test.tsx src/context/AuthContext.tsx src/context/AuthProvider.tsx src/components/Login/LoginForm.tsx --no-warn-ignored`
- `pnpm build`

<img width="978" height="968" alt="Screenshot 2026-05-23 at 8 11 01 PM" src="https://github.com/user-attachments/assets/99a4afec-8838-41f1-9736-c48484230588" />
<img width="2880" height="1372" alt="Screenshot 2026-05-23 at 9 27 53 PM" src="https://github.com/user-attachments/assets/af4df246-6325-44ef-9045-ef790d0a0b65" />
