### PR TITLE
fix: hide history load more when no next page

### DIFF
--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -48,7 +48,7 @@ export const HistoryPage = () => {
     refetchOnWindowFocus: false,
     initialPageParam: 0,
     getNextPageParam: (lastPage, _allPages, lastPageParam) => {
-      if (lastPage.length === 0) {
+      if (lastPage.length < HISTORY_NB_ALERTS_PER_PAGE) {
         return undefined;
       }
       return lastPageParam + 1;


### PR DESCRIPTION
## Summary
- stop History pagination when the last loaded page contains fewer alerts than the configured page size
- hide the Load more alerts button when there is no next page

Closes #160

## Tests
- pnpm exec eslint src/pages/HistoryPage.tsx --no-warn-ignored
- git diff --check
- pnpm build

See screenshot below. Load more history button doesn't appear when there's no more "next page" 

<img width="770" height="1388" alt="Screenshot 2026-05-23 at 10 26 27 PM" src="https://github.com/user-attachments/assets/076b800e-d1df-4c5f-ae67-57a07236aa8b" />
