### PR TITLE
feat: hide live error snackbar

### DIFF
--- a/src/components/Live/LiveContainer.tsx
+++ b/src/components/Live/LiveContainer.tsx
@@ -20,7 +20,6 @@ import { useActionsOnCamera } from './context/useActionsOnCamera';
 import { useDataSitesLive } from './hooks/useDataSitesLive';
 import { HeadRow } from './LiveContent/HeadRow/HeadRow';
 import { LiveControlPanel } from './LiveContent/LiveControlPanel';
-import LiveErrorSnackbar from './LiveContent/LiveErrorSnackbar';
 import { LiveStreamPanel } from './LiveContent/LiveStreamPanel';
 
 interface LiveContainerProps {
@@ -101,7 +100,6 @@ export const LiveContainer = ({
 
   return (
     <>
-      <LiveErrorSnackbar />
       <Stack height="100%">
         <HeadRow
           onClose={onClose}


### PR DESCRIPTION
- Stop showing the red error snackbar in live streaming when a streaming action (start/stop/move/zoom) fails.
- Removes only the `<LiveErrorSnackbar />` render and its import in `LiveContainer.tsx`.
- Retry/relaunch logic and error state are untouched; the `LiveErrorSnackbar` component is kept for easy re-enabling.