### PR TITLE
Add sequence unmatch action to alert details

### DIFF
--- a/src/components/Alerts/AlertDetails/AlertHeader.tsx
+++ b/src/components/Alerts/AlertDetails/AlertHeader.tsx
@@ -71,6 +71,7 @@ export const AlertHeader = ({
               alert={alert}
               selectedSequence={selectedSequence}
               setSelectedSequence={setSelectedSequence}
+              invalidateAndRefreshData={invalidateAndRefreshData}
             />
           </div>
         </Stack>
@@ -99,6 +100,7 @@ export const AlertHeader = ({
             alert={alert}
             selectedSequence={selectedSequence}
             setSelectedSequence={setSelectedSequence}
+            invalidateAndRefreshData={invalidateAndRefreshData}
           />
         </Stack>
       )}

--- a/src/components/Alerts/AlertDetails/AlertHeader.tsx
+++ b/src/components/Alerts/AlertDetails/AlertHeader.tsx
@@ -12,7 +12,7 @@ import { useIsMobile } from '@/utils/useIsMobile';
 import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
 
 import { SequenceLabelContainer } from '../AlertLabel/SequenceLabelContainer';
-import { SequenceSelector } from './SequenceSelector';
+import { AlertSequenceControls } from './AlertSequenceControls';
 
 interface AlertHeaderType {
   isLiveMode: boolean;
@@ -38,29 +38,6 @@ export const AlertHeader = ({
 
   const camera = selectedSequence.camera;
 
-  const Title = (
-    <Typography variant="h1">
-      {camera?.name ?? t('defaultCameraName')}
-    </Typography>
-  );
-
-  const SequenceLabel = (
-    <SequenceLabelContainer
-      sequence={selectedSequence}
-      isLiveMode={isLiveMode}
-      invalidateAndRefreshData={invalidateAndRefreshData}
-      nbSequencesToBeLabelled={countUnlabelledSequences(alert.sequences)}
-    />
-  );
-
-  const SequenceSelectorComponent = alert.sequences.length > 1 && (
-    <SequenceSelector
-      alert={alert}
-      setSelectedSequence={setSelectedSequence}
-      selectedSequence={selectedSequence}
-    />
-  );
-
   return (
     <>
       {isMobile ? (
@@ -77,10 +54,25 @@ export const AlertHeader = ({
             >
               <ArrowBackIcon />
             </IconButton>
-            {Title}
-            {SequenceLabel}
+            <Typography variant="h1">
+              {camera?.name ?? t('defaultCameraName')}
+            </Typography>
+            <SequenceLabelContainer
+              sequence={selectedSequence}
+              isLiveMode={isLiveMode}
+              invalidateAndRefreshData={invalidateAndRefreshData}
+              nbSequencesToBeLabelled={countUnlabelledSequences(
+                alert.sequences
+              )}
+            />
           </Stack>
-          <div style={{ alignSelf: 'center' }}>{SequenceSelectorComponent}</div>
+          <div style={{ alignSelf: 'center' }}>
+            <AlertSequenceControls
+              alert={alert}
+              selectedSequence={selectedSequence}
+              setSelectedSequence={setSelectedSequence}
+            />
+          </div>
         </Stack>
       ) : (
         <Stack
@@ -91,10 +83,23 @@ export const AlertHeader = ({
         >
           <Stack direction="row" spacing={1} alignItems="center">
             <img src={smallLogo} height="26px" width="26px" />
-            {Title}
-            {SequenceLabel}
+            <Typography variant="h1">
+              {camera?.name ?? t('defaultCameraName')}
+            </Typography>
+            <SequenceLabelContainer
+              sequence={selectedSequence}
+              isLiveMode={isLiveMode}
+              invalidateAndRefreshData={invalidateAndRefreshData}
+              nbSequencesToBeLabelled={countUnlabelledSequences(
+                alert.sequences
+              )}
+            />
           </Stack>
-          {SequenceSelectorComponent}
+          <AlertSequenceControls
+            alert={alert}
+            selectedSequence={selectedSequence}
+            setSelectedSequence={setSelectedSequence}
+          />
         </Stack>
       )}
     </>

--- a/src/components/Alerts/AlertDetails/AlertSequenceControls.tsx
+++ b/src/components/Alerts/AlertDetails/AlertSequenceControls.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/utils/alerts';
 
 import { SequenceSelector } from './SequenceSelector';
+import { SequenceUnmatchContainer } from './SequenceUnmatchContainer';
 
 interface AlertSequenceControlsProps {
   alert: AlertType;
@@ -14,12 +15,14 @@ interface AlertSequenceControlsProps {
   setSelectedSequence: Dispatch<
     SetStateAction<SequenceWithCameraInfoType | null>
   >;
+  invalidateAndRefreshData: () => void;
 }
 
 export const AlertSequenceControls = ({
   alert,
   selectedSequence,
   setSelectedSequence,
+  invalidateAndRefreshData,
 }: AlertSequenceControlsProps) => {
   if (alert.sequences.length <= 1) {
     return null;
@@ -31,6 +34,11 @@ export const AlertSequenceControls = ({
         alert={alert}
         setSelectedSequence={setSelectedSequence}
         selectedSequence={selectedSequence}
+      />
+      <SequenceUnmatchContainer
+        alert={alert}
+        sequence={selectedSequence}
+        invalidateAndRefreshData={invalidateAndRefreshData}
       />
     </Stack>
   );

--- a/src/components/Alerts/AlertDetails/AlertSequenceControls.tsx
+++ b/src/components/Alerts/AlertDetails/AlertSequenceControls.tsx
@@ -1,0 +1,37 @@
+import { Stack } from '@mui/material';
+import { type Dispatch, type SetStateAction } from 'react';
+
+import {
+  type AlertType,
+  type SequenceWithCameraInfoType,
+} from '@/utils/alerts';
+
+import { SequenceSelector } from './SequenceSelector';
+
+interface AlertSequenceControlsProps {
+  alert: AlertType;
+  selectedSequence: SequenceWithCameraInfoType;
+  setSelectedSequence: Dispatch<
+    SetStateAction<SequenceWithCameraInfoType | null>
+  >;
+}
+
+export const AlertSequenceControls = ({
+  alert,
+  selectedSequence,
+  setSelectedSequence,
+}: AlertSequenceControlsProps) => {
+  if (alert.sequences.length <= 1) {
+    return null;
+  }
+
+  return (
+    <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent="center">
+      <SequenceSelector
+        alert={alert}
+        setSelectedSequence={setSelectedSequence}
+        selectedSequence={selectedSequence}
+      />
+    </Stack>
+  );
+};

--- a/src/components/Alerts/AlertDetails/SequenceUnmatchContainer.test.tsx
+++ b/src/components/Alerts/AlertDetails/SequenceUnmatchContainer.test.tsx
@@ -1,0 +1,89 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { unmatchSequenceFromAlert } from '@/services/alerts';
+import type { SequenceWithCameraInfoType } from '@/utils/alerts';
+
+import TestProviders from '../../../test/TestProviders';
+import { SequenceUnmatchContainer } from './SequenceUnmatchContainer';
+
+vi.mock('@/services/alerts', () => ({
+  unmatchSequenceFromAlert: vi.fn(),
+}));
+
+const createSequence = (id: number): SequenceWithCameraInfoType => ({
+  id,
+  poseId: null,
+  camera: null,
+  startedAt: null,
+  lastSeenAt: null,
+  azimuth: 0,
+  coneAngle: 0,
+  labelWildfire: null,
+});
+
+const renderContainer = (
+  sequences = [createSequence(1), createSequence(2)]
+) => {
+  const invalidateAndRefreshData = vi.fn();
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <TestProviders>
+        <SequenceUnmatchContainer
+          alert={{ id: 42, startedAt: null, sequences }}
+          sequence={sequences[0]}
+          invalidateAndRefreshData={invalidateAndRefreshData}
+        />
+      </TestProviders>
+    </QueryClientProvider>
+  );
+
+  return { invalidateAndRefreshData };
+};
+
+describe('SequenceUnmatchContainer', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('hides the control when the alert has only one sequence', () => {
+    renderContainer([createSequence(1)]);
+
+    expect(
+      screen.queryByRole('button', { name: /unmatch sequence/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('unmatches the selected sequence and refreshes the alert', async () => {
+    vi.mocked(unmatchSequenceFromAlert).mockResolvedValue(true);
+    const { invalidateAndRefreshData } = renderContainer();
+
+    fireEvent.click(screen.getByRole('button', { name: /unmatch sequence/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^unmatch$/i }));
+
+    await waitFor(() => {
+      expect(unmatchSequenceFromAlert).toHaveBeenCalledWith(1, 42);
+      expect(invalidateAndRefreshData).toHaveBeenCalledOnce();
+    });
+
+    expect(await screen.findByText('Sequence unmatched')).toBeInTheDocument();
+  });
+
+  it('shows an error when the request fails', async () => {
+    vi.mocked(unmatchSequenceFromAlert).mockRejectedValue(new Error('failure'));
+    renderContainer();
+
+    fireEvent.click(screen.getByRole('button', { name: /unmatch sequence/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^unmatch$/i }));
+
+    expect(
+      await screen.findByText(
+        'Unable to unmatch the sequence. Please try again.'
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/Alerts/AlertDetails/SequenceUnmatchContainer.tsx
+++ b/src/components/Alerts/AlertDetails/SequenceUnmatchContainer.tsx
@@ -1,0 +1,118 @@
+import LinkOffIcon from '@mui/icons-material/LinkOff';
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Snackbar from '@mui/material/Snackbar';
+import Typography from '@mui/material/Typography';
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+
+import { unmatchSequenceFromAlert } from '@/services/alerts';
+import {
+  type AlertType,
+  type SequenceWithCameraInfoType,
+} from '@/utils/alerts';
+import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
+
+interface SequenceUnmatchContainerProps {
+  alert: AlertType;
+  sequence: SequenceWithCameraInfoType;
+  invalidateAndRefreshData: () => void;
+}
+
+export const SequenceUnmatchContainer = ({
+  alert,
+  sequence,
+  invalidateAndRefreshData,
+}: SequenceUnmatchContainerProps) => {
+  const { t } = useTranslationPrefix('alerts');
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [snackbarStatus, setSnackbarStatus] = useState<
+    'success' | 'error' | null
+  >(null);
+
+  const unmatchMutation = useMutation({
+    mutationFn: async () => {
+      const isUnmatched = await unmatchSequenceFromAlert(sequence.id, alert.id);
+
+      if (!isUnmatched) {
+        throw new Error('INVALID_API_RESPONSE');
+      }
+    },
+    onSuccess: () => {
+      invalidateAndRefreshData();
+      setIsDialogOpen(false);
+      setSnackbarStatus('success');
+    },
+    onError: () => {
+      setSnackbarStatus('error');
+    },
+  });
+
+  if (alert.sequences.length <= 1) {
+    return null;
+  }
+
+  const cameraName = sequence.camera?.name ?? t('defaultCameraName');
+  const isPending = unmatchMutation.isPending;
+  const closeDialog = () => {
+    if (!isPending) {
+      setIsDialogOpen(false);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        color="error"
+        variant="outlined"
+        startIcon={<LinkOffIcon />}
+        onClick={() => setIsDialogOpen(true)}
+      >
+        {t('unmatch.button')}
+      </Button>
+      <Dialog
+        open={isDialogOpen}
+        onClose={closeDialog}
+        disableEscapeKeyDown={isPending}
+      >
+        <DialogTitle>{t('unmatch.title', { cameraName })}</DialogTitle>
+        <DialogContent dividers>
+          <Typography>{t('unmatch.description')}</Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeDialog} disabled={isPending}>
+            {t('unmatch.buttonCancel')}
+          </Button>
+          <Button
+            color="error"
+            variant="contained"
+            onClick={() => unmatchMutation.mutate()}
+            disabled={isPending}
+          >
+            {t(isPending ? 'unmatch.buttonLoading' : 'unmatch.buttonConfirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Snackbar
+        open={snackbarStatus !== null}
+        autoHideDuration={5000}
+        onClose={() => setSnackbarStatus(null)}
+      >
+        <Alert
+          severity={snackbarStatus ?? 'error'}
+          variant="filled"
+          onClose={() => setSnackbarStatus(null)}
+          sx={{ width: '100%' }}
+        >
+          {t(
+            snackbarStatus === 'success' ? 'unmatch.success' : 'unmatch.error'
+          )}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+};

--- a/src/components/Alerts/AlertDetails/SequenceUnmatchContainer.tsx
+++ b/src/components/Alerts/AlertDetails/SequenceUnmatchContainer.tsx
@@ -23,6 +23,8 @@ interface SequenceUnmatchContainerProps {
   invalidateAndRefreshData: () => void;
 }
 
+const DURATION_SNACKBAR_MS = 5000;
+
 export const SequenceUnmatchContainer = ({
   alert,
   sequence,
@@ -63,6 +65,7 @@ export const SequenceUnmatchContainer = ({
       setIsDialogOpen(false);
     }
   };
+  const closeSnackbar = () => setSnackbarStatus(null);
 
   return (
     <>
@@ -99,13 +102,13 @@ export const SequenceUnmatchContainer = ({
       </Dialog>
       <Snackbar
         open={snackbarStatus !== null}
-        autoHideDuration={5000}
-        onClose={() => setSnackbarStatus(null)}
+        autoHideDuration={DURATION_SNACKBAR_MS}
+        onClose={closeSnackbar}
       >
         <Alert
           severity={snackbarStatus ?? 'error'}
           variant="filled"
-          onClose={() => setSnackbarStatus(null)}
+          onClose={closeSnackbar}
           sx={{ width: '100%' }}
         >
           {t(

--- a/src/components/Alerts/AlertDetails/SequenceUnmatchContainer.tsx
+++ b/src/components/Alerts/AlertDetails/SequenceUnmatchContainer.tsx
@@ -15,6 +15,7 @@ import {
   type AlertType,
   type SequenceWithCameraInfoType,
 } from '@/utils/alerts';
+import { SNACKBAR_AUTO_HIDE_DURATION_MS } from '@/utils/snackbar';
 import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
 
 interface SequenceUnmatchContainerProps {
@@ -22,8 +23,6 @@ interface SequenceUnmatchContainerProps {
   sequence: SequenceWithCameraInfoType;
   invalidateAndRefreshData: () => void;
 }
-
-const DURATION_SNACKBAR_MS = 5000;
 
 export const SequenceUnmatchContainer = ({
   alert,
@@ -102,7 +101,7 @@ export const SequenceUnmatchContainer = ({
       </Dialog>
       <Snackbar
         open={snackbarStatus !== null}
-        autoHideDuration={DURATION_SNACKBAR_MS}
+        autoHideDuration={SNACKBAR_AUTO_HIDE_DURATION_MS}
         onClose={closeSnackbar}
       >
         <Alert

--- a/src/components/Alerts/AlertDetails/SequenceUnmatchContainer.tsx
+++ b/src/components/Alerts/AlertDetails/SequenceUnmatchContainer.tsx
@@ -93,9 +93,9 @@ export const SequenceUnmatchContainer = ({
             color="error"
             variant="contained"
             onClick={() => unmatchMutation.mutate()}
-            disabled={isPending}
+            loading={isPending}
           >
-            {t(isPending ? 'unmatch.buttonLoading' : 'unmatch.buttonConfirm')}
+            {t('unmatch.buttonConfirm')}
           </Button>
         </DialogActions>
       </Dialog>

--- a/src/components/Alerts/AlertLabel/SequenceLabelSnackbar.tsx
+++ b/src/components/Alerts/AlertLabel/SequenceLabelSnackbar.tsx
@@ -1,14 +1,14 @@
 import Alert from '@mui/material/Alert';
 import Snackbar from '@mui/material/Snackbar';
 
+import { SNACKBAR_AUTO_HIDE_DURATION_MS } from '@/utils/snackbar';
+
 interface SequenceLabelSnackbarProps {
   open: boolean;
   handleClose: () => void;
   isSuccess: boolean | null;
   message: string;
 }
-
-const DURATION_SNACKBAR_MS = 5000;
 
 export const SequenceLabelSnackbar = ({
   open,
@@ -19,7 +19,7 @@ export const SequenceLabelSnackbar = ({
   return (
     <Snackbar
       open={open}
-      autoHideDuration={DURATION_SNACKBAR_MS}
+      autoHideDuration={SNACKBAR_AUTO_HIDE_DURATION_MS}
       onClose={handleClose}
     >
       <Alert

--- a/src/components/Live/LiveContent/LiveErrorSnackbar.tsx
+++ b/src/components/Live/LiveContent/LiveErrorSnackbar.tsx
@@ -1,15 +1,15 @@
 import { Alert, Snackbar } from '@mui/material';
 
-import { useActionsOnCamera } from '../context/useActionsOnCamera';
+import { SNACKBAR_AUTO_HIDE_DURATION_MS } from '@/utils/snackbar';
 
-const DURATION_SNACKBAR_IN_MS = 5000;
+import { useActionsOnCamera } from '../context/useActionsOnCamera';
 
 export const LiveErrorSnackbar = () => {
   const { errorStreamingAction, resetErrorOnAction } = useActionsOnCamera();
   return (
     <Snackbar
       open={!!errorStreamingAction}
-      autoHideDuration={DURATION_SNACKBAR_IN_MS}
+      autoHideDuration={SNACKBAR_AUTO_HIDE_DURATION_MS}
       onClose={resetErrorOnAction}
     >
       <Alert

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -93,6 +93,16 @@
     "buttonModifyAlert": "Alarm ändern",
     "buttonShare": "Teilen",
     "shareLinkCopied": "Alarm-Link in die Zwischenablage kopiert",
+    "unmatch": {
+      "button": "Sequenz trennen",
+      "title": "Sequenz von {{cameraName}} trennen?",
+      "description": "Dies kann nicht rückgängig gemacht werden. Die Sequenz wird aus diesem Alarm entfernt und kann einen neuen Alarm erstellen.",
+      "buttonCancel": "Abbrechen",
+      "buttonConfirm": "Trennen",
+      "buttonLoading": "Wird getrennt...",
+      "success": "Sequenz getrennt",
+      "error": "Die Sequenz konnte nicht getrennt werden. Bitte versuchen Sie es erneut."
+    },
     "copyText": "Kopiert",
     "blinkingMode": {
       "buttonBlinkingView": "Zur Blinkanzeige wechseln",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -99,7 +99,6 @@
       "description": "Dies kann nicht rückgängig gemacht werden. Die Sequenz wird aus diesem Alarm entfernt und kann einen neuen Alarm erstellen.",
       "buttonCancel": "Abbrechen",
       "buttonConfirm": "Trennen",
-      "buttonLoading": "Wird getrennt...",
       "success": "Sequenz getrennt",
       "error": "Die Sequenz konnte nicht getrennt werden. Bitte versuchen Sie es erneut."
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -93,6 +93,16 @@
     "buttonModifyAlert": "Modify the alert",
     "buttonShare": "Share",
     "shareLinkCopied": "Alert link copied to clipboard",
+    "unmatch": {
+      "button": "Unmatch sequence",
+      "title": "Unmatch sequence from {{cameraName}}?",
+      "description": "This cannot be undone. The sequence will be removed from this alert and may create a new alert.",
+      "buttonCancel": "Cancel",
+      "buttonConfirm": "Unmatch",
+      "buttonLoading": "Unmatching...",
+      "success": "Sequence unmatched",
+      "error": "Unable to unmatch the sequence. Please try again."
+    },
     "copyText": "Copied",
     "blinkingMode": {
       "buttonBlinkingView": "Switch to blinking view",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -99,7 +99,6 @@
       "description": "This cannot be undone. The sequence will be removed from this alert and may create a new alert.",
       "buttonCancel": "Cancel",
       "buttonConfirm": "Unmatch",
-      "buttonLoading": "Unmatching...",
       "success": "Sequence unmatched",
       "error": "Unable to unmatch the sequence. Please try again."
     },

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -93,6 +93,16 @@
     "buttonModifyAlert": "Modificar la alerta",
     "buttonShare": "Compartir",
     "shareLinkCopied": "Enlace de la alerta copiado al portapapeles",
+    "unmatch": {
+      "button": "Desvincular secuencia",
+      "title": "¿Desvincular la secuencia de {{cameraName}}?",
+      "description": "Esta acción no se puede deshacer. La secuencia se eliminará de esta alerta y puede crear una nueva alerta.",
+      "buttonCancel": "Cancelar",
+      "buttonConfirm": "Desvincular",
+      "buttonLoading": "Desvinculando...",
+      "success": "Secuencia desvinculada",
+      "error": "No se ha podido desvincular la secuencia. Vuelva a intentarlo."
+    },
     "copyText": "Copiado",
     "blinkingMode": {
       "buttonBlinkingView": "Cambiar a vista parpadeante",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -99,7 +99,6 @@
       "description": "Esta acción no se puede deshacer. La secuencia se eliminará de esta alerta y puede crear una nueva alerta.",
       "buttonCancel": "Cancelar",
       "buttonConfirm": "Desvincular",
-      "buttonLoading": "Desvinculando...",
       "success": "Secuencia desvinculada",
       "error": "No se ha podido desvincular la secuencia. Vuelva a intentarlo."
     },

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -93,6 +93,16 @@
     "buttonModifyAlert": "Modifier l'alerte",
     "buttonShare": "Partager",
     "shareLinkCopied": "Lien de l'alerte copié dans le presse-papier",
+    "unmatch": {
+      "button": "Dissocier la séquence",
+      "title": "Dissocier la séquence de {{cameraName}} ?",
+      "description": "Cette action est irréversible. La séquence sera retirée de cette alerte et pourra créer une nouvelle alerte.",
+      "buttonCancel": "Annuler",
+      "buttonConfirm": "Dissocier",
+      "buttonLoading": "Dissociation...",
+      "success": "Séquence dissociée",
+      "error": "Impossible de dissocier la séquence. Veuillez réessayer."
+    },
     "copyText": "Copié",
     "blinkingMode": {
       "buttonBlinkingView": "Passer en vue clignotante",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -99,7 +99,6 @@
       "description": "Cette action est irréversible. La séquence sera retirée de cette alerte et pourra créer une nouvelle alerte.",
       "buttonCancel": "Annuler",
       "buttonConfirm": "Dissocier",
-      "buttonLoading": "Dissociation...",
       "success": "Séquence dissociée",
       "error": "Impossible de dissocier la séquence. Veuillez réessayer."
     },

--- a/src/services/alerts.ts
+++ b/src/services/alerts.ts
@@ -172,3 +172,27 @@ export const labelBySequenceId = async (
       throw err;
     });
 };
+
+export const unmatchSequenceFromAlert = async (
+  sequenceId: number,
+  alertId: number
+) => {
+  return apiInstance
+    .post(`/api/v1/alerts/${alertId}/sequences/${sequenceId}/unmatch`)
+    .then((response: AxiosResponse) => {
+      try {
+        if (response.data === null) {
+          return true;
+        }
+
+        const result = apiAlertResponseSchema.safeParse(response.data);
+        return result.success;
+      } catch {
+        throw new Error('INVALID_API_RESPONSE');
+      }
+    })
+    .catch((err: unknown) => {
+      console.error(err);
+      throw err;
+    });
+};

--- a/src/utils/snackbar.ts
+++ b/src/utils/snackbar.ts
@@ -1,0 +1,1 @@
+export const SNACKBAR_AUTO_HIDE_DURATION_MS = 5000;


### PR DESCRIPTION
## Summary
- add a confirmed, destructive unmatch action beside the sequence selector
- refresh alert data and provide success/error feedback after the API call
- localize the action and extract sequence controls from the header

Closes #246

## Demo


https://github.com/user-attachments/assets/9b144dbc-e4e2-4695-9fbe-dbbd917ef03a

