### PR TITLE
#247: fix zoom indicator display bug on download click (wrong z index)

### DIFF
--- a/src/components/Alerts/AlertDetails/AlertImages/AlertImages.tsx
+++ b/src/components/Alerts/AlertDetails/AlertImages/AlertImages.tsx
@@ -243,7 +243,12 @@ export const AlertImages = ({ sequence }: AlertImagesType) => {
           spacing={{ xs: 1, sm: 2 }}
           minHeight={35}
           useFlexGap
-          sx={{ flexWrap: 'wrap', rowGap: 1 }}
+          sx={{
+            flexWrap: 'wrap',
+            rowGap: 1,
+            position: 'relative',
+            zIndex: 10,
+          }}
         >
           <Typography variant="h2">
             {formatIsoToTime(sequence.startedAt)}


### PR DESCRIPTION
Bug #247 solved: wrong z index.
I propose this correction, but other possibilities exists.