### PR TITLE
feat #254 : switch map position and set it as default view

### DIFF
--- a/src/components/Dashboard/DashboardContainer.tsx
+++ b/src/components/Dashboard/DashboardContainer.tsx
@@ -25,8 +25,8 @@ interface DashboardContainerProps {
   cameraList: CameraType[] | undefined;
 }
 
-const TAB_CARDS = 0;
-const TAB_MAP = 1;
+const TAB_MAP = 0;
+const TAB_CARDS = 1;
 
 export const DashboardContainer = ({
   status,
@@ -65,8 +65,8 @@ export const DashboardContainer = ({
                 p={2}
               >
                 <Tabs value={indexTab} onChange={handleChange}>
-                  <Tab icon={<GridViewIcon />} aria-label="gridViewIcon" />
                   <Tab icon={<MapIcon />} aria-label="mapIcon" />
+                  <Tab icon={<GridViewIcon />} aria-label="gridViewIcon" />
                 </Tabs>
                 <LastUpdateButton
                   lastUpdate={lastUpdate}


### PR DESCRIPTION
In dashboard view, switch map position and set it as default view.
<img width="1852" height="546" alt="image" src="https://github.com/user-attachments/assets/14aafe80-965c-48af-a0b3-5a6cb0a886ad" />
