### PR TITLE
fix: use capture timestamps for alert detections

### DIFF
--- a/src/components/Alerts/AlertDetails/AlertImages/AlertImagesPlayer.tsx
+++ b/src/components/Alerts/AlertDetails/AlertImages/AlertImagesPlayer.tsx
@@ -51,11 +51,11 @@ export const AlertImagesPlayer = ({
   const marks = useMemo(
     () =>
       detections.map((d, i) => ({
-        value: convertIsoToUnix(d.created_at),
+        value: convertIsoToUnix(d.recorded_at),
         id: d.id,
         label:
           i == 0 || i == detections.length - 1
-            ? formatIsoToTime(d.created_at)
+            ? formatIsoToTime(d.recorded_at)
             : null,
       })),
     [detections]
@@ -148,13 +148,15 @@ export const AlertImagesPlayer = ({
             />
             <Box sx={{ flexGrow: 1, width: '100%', mr: 2, px: 3, pt: 3 }}>
               <Slider
-                value={convertIsoToUnix(selectedDetection.created_at)}
+                value={convertIsoToUnix(selectedDetection.recorded_at)}
                 onChange={onChangeSlider}
                 min={Math.min(...marks.map((mark) => mark.value))}
                 max={Math.max(...marks.map((mark) => mark.value))}
                 step={null}
                 valueLabelDisplay={isPlaying ? 'off' : 'on'}
-                valueLabelFormat={formatIsoToTime(selectedDetection.created_at)}
+                valueLabelFormat={formatIsoToTime(
+                  selectedDetection.recorded_at
+                )}
                 marks={marks}
                 sx={{
                   verticalAlign: 'middle',

--- a/src/services/alerts.test.ts
+++ b/src/services/alerts.test.ts
@@ -1,0 +1,44 @@
+import { getDetectionsBySequence } from './alerts';
+
+const { mockGet } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+}));
+
+vi.mock('./axios', () => ({
+  apiInstance: {
+    get: mockGet,
+  },
+}));
+
+const detection = (id: number, createdAt: string, recordedAt: string) => ({
+  id,
+  camera_id: 10,
+  pose_id: 20,
+  sequence_id: 30,
+  bucket_key: `detection-${id}`,
+  bbox: '[]',
+  others_bboxes: null,
+  created_at: createdAt,
+  recorded_at: recordedAt,
+  url: `https://example.com/detection-${id}.jpg`,
+  crop_url: null,
+});
+
+describe('getDetectionsBySequence', () => {
+  it('orders detections by their capture time and preserves it', async () => {
+    mockGet.mockResolvedValue({
+      data: [
+        detection(1, '2026-07-01T10:00:00', '2026-07-01T10:00:20'),
+        detection(2, '2026-07-01T10:00:10', '2026-07-01T10:00:05'),
+      ],
+    });
+
+    const result = await getDetectionsBySequence(30);
+
+    expect(result.map(({ id }) => id)).toEqual([2, 1]);
+    expect(result.map((item) => item.recorded_at)).toEqual([
+      '2026-07-01T10:00:05',
+      '2026-07-01T10:00:20',
+    ]);
+  });
+});

--- a/src/services/alerts.ts
+++ b/src/services/alerts.ts
@@ -34,6 +34,7 @@ const apiDetectionResponseSchema = z.object({
   bbox: z.string(),
   others_bboxes: z.nullable(z.string()),
   created_at: z.iso.datetime({ local: true }),
+  recorded_at: z.iso.datetime({ local: true }),
   url: z.string(),
   crop_url: z.string().nullish(),
 });
@@ -137,7 +138,8 @@ export const getDetectionsBySequence = async (
         if (result.data) {
           result.data.sort(
             (d1, d2) =>
-              convertIsoToUnix(d1.created_at) - convertIsoToUnix(d2.created_at)
+              convertIsoToUnix(d1.recorded_at) -
+              convertIsoToUnix(d2.recorded_at)
           );
         }
         return result.data ?? [];


### PR DESCRIPTION
Closes #146

## Changes

Detection responses now parse `recorded_at`. The sequence service sorts detections by that capture timestamp. The player uses the same timestamp for slider positions, endpoint labels & the selected value label. Database `created_at` values no longer control playback order.

The regression test supplies two detections whose database & capture timestamps sort in opposite directions. It expects the capture-time order.

## Verification

- Vitest: 13 files, 113 tests passed
- TypeScript project build
- Prettier check on the 3 changed files
- ESLint on the 3 changed files