### PR TITLE
fix(277): [Livestreaming] update azimuth on inital move

### DIFF
--- a/src/components/Live/LiveContainer.tsx
+++ b/src/components/Live/LiveContainer.tsx
@@ -128,8 +128,8 @@ export const LiveContainer = ({
   }, [invalidateAndRefreshAzimuthCamera, isOneActionLoading]);
 
   useEffect(() => {
-    setIsMoving(liveAzimuth?.moving ?? false);
-  }, [liveAzimuth]);
+    setIsMoving(isOneActionLoading || (liveAzimuth?.moving ?? false));
+  }, [isOneActionLoading, liveAzimuth]);
 
   const isStreamingLaunched =
     statusSitesFetch == STATUS_SUCCESS &&

--- a/src/components/Live/context/ActionsOnCameraProvider.tsx
+++ b/src/components/Live/context/ActionsOnCameraProvider.tsx
@@ -27,7 +27,7 @@ import {
 } from '../context/ActionsOnCameraContext';
 
 const MAX_RETRY_ON_ACTIONS = 3;
-const TIME_BETWEEN_START_AND_MOVE_MS = 5000;
+const TIME_BETWEEN_START_AND_MOVE_MS = 3000;
 const LIVE_STREAMING_TIMEOUT_MS =
   appConfig.getConfig().LIVE_STREAMING_TIMEOUT_SECONDS * 1000;
 

--- a/src/components/Live/context/ActionsOnCameraProvider.tsx
+++ b/src/components/Live/context/ActionsOnCameraProvider.tsx
@@ -27,7 +27,7 @@ import {
 } from '../context/ActionsOnCameraContext';
 
 const MAX_RETRY_ON_ACTIONS = 3;
-const TIME_BETWEEN_START_AND_MOVE_MS = 3000;
+const TIME_BETWEEN_START_AND_MOVE_MS = 5000;
 const LIVE_STREAMING_TIMEOUT_MS =
   appConfig.getConfig().LIVE_STREAMING_TIMEOUT_SECONDS * 1000;
 
@@ -47,6 +47,15 @@ export const ActionsOnCameraContextProvider: React.FC<{
   >(null);
   const { t } = useTranslationPrefix('live');
 
+  const createAwaitPromise = () =>
+    new Promise((resolve) => {
+      setTimerBeforeInitialMove(
+        window.setTimeout(() => {
+          resolve(null);
+        }, TIME_BETWEEN_START_AND_MOVE_MS)
+      );
+    });
+
   const { mutateAsync: startStreamingMutate, status: statusStart } =
     useMutation({
       retry: MAX_RETRY_ON_ACTIONS,
@@ -54,23 +63,26 @@ export const ActionsOnCameraContextProvider: React.FC<{
         id: number;
         hasRotation: boolean;
         initialMove?: MovementCommand;
-      }) =>
-        params.hasRotation
-          ? stopPatrolThenStartStreaming(params.id).then(() => {
-              if (params.initialMove) {
-                // fix: wait a few seconds before calling for move
-                // (problem in the pi)
-                setTimerBeforeInitialMove(
-                  window.setTimeout(
+      }) => {
+        if (params.hasRotation) {
+          return (
+            stopPatrolThenStartStreaming(params.id)
+              // fix: wait a few seconds before calling for move
+              // (problem in the pi)
+              .then(() => {
+                if (params.initialMove) {
+                  return createAwaitPromise().then(
                     () =>
                       params.initialMove &&
-                      moveCameraToAAzimuth(params.id, params.initialMove),
-                    TIME_BETWEEN_START_AND_MOVE_MS
-                  )
-                );
-              }
-            })
-          : startStreaming(params.id),
+                      moveCameraToAAzimuth(params.id, params.initialMove)
+                  );
+                }
+              })
+          );
+        } else {
+          return startStreaming(params.id);
+        }
+      },
     });
 
   const { mutateAsync: stopStreamingMutate, status: statusStop } = useMutation({


### PR DESCRIPTION
The problem is when opening livestreaming with an alert, more precisely, it's when we ask the camera to move to the alert's pose. Azimuth is not hot reloaded while doing this initial move

- Chain action "initial move" with the action "start" (one promise)  : 
   - Before (initial move is outside promise) : Promise = Start streaming -> create timer which triggers initial move 
   - After : Promise = Start streaming -> wait for timer -> start initial move
   - With this change, my param isOneActionLoading is still at true while initial move is loading

- Hot reload (refetch interval high) when one action is loading


