### PR TITLE
fix: bypass browser cache on alert image ZIP downloads

### DIFF
--- a/src/components/Alerts/AlertDetails/AlertImages/AlertImagesActions.tsx
+++ b/src/components/Alerts/AlertDetails/AlertImages/AlertImagesActions.tsx
@@ -126,7 +126,9 @@ const AlertImagesActions = ({
     const zip = new JSZip();
 
     const fetchPromises = detections.map(async (detection) => {
-      const response = await fetch(detection.url);
+      // Bypass the browser cache: the <img> tags load the same URLs without
+      // CORS, and reusing those cached responses here fails the CORS check
+      const response = await fetch(detection.url, { cache: 'reload' });
       const blob = await response.blob();
       const extension = detection.url.split('.').pop()?.split('?')[0] ?? 'jpg';
       // Format: YYYY-MM-DDTHH-MM-SS_DETECTION_ID.extension
@@ -149,7 +151,9 @@ const AlertImagesActions = ({
     const zip = new JSZip();
 
     const fetchPromises = detections.map(async (detection) => {
-      const response = await fetch(detection.url);
+      // Bypass the browser cache: the <img> tags load the same URLs without
+      // CORS, and reusing those cached responses here fails the CORS check
+      const response = await fetch(detection.url, { cache: 'reload' });
       const blob = await response.blob();
       const extension = detection.url.split('.').pop()?.split('?')[0] ?? 'jpg';
       // Format: YYYY-MM-DDTHH-MM-SS_DETECTION_ID.extension


### PR DESCRIPTION
fixes #242 

## Context

The "download all" and "download all + bounding boxes" buttons fetch each detection image from S3 to build the ZIP. Those `fetch()` calls are CORS requests, but the viewer's `<img>` tags load the _same_ presigned URLs without `crossOrigin`, so the browser may have a no-CORS response cached for that URL. That cached response can't satisfy the CORS fetch, and the download fails.

Adding `cache: 'reload'` forces a fresh network GET so each image is
fetched with the right CORS context.

This PR will solve #242 once https://github.com/pyronear/pyro-api/pull/674 is deployed API side (and after backfilling existing prod/preprod buckets with CORS rules)

As I am not fluent in React, this PR has been Investigated and patched with Claude Code


## Performance

No change in request count — the feature already does one `fetch()` per detection, fired in parallel. `cache: 'reload'` only means those requests skip the cache lookup. In practice most were already missing the cache: presigned URLs are re-signed on every detections refetch (new query string = new cache key), and only frames the player has stepped through
were ever cached. Bounded by one sequence's frame count, on an explicit user action.

`'reload'` over `'no-store'` so the fetched bytes still populate the cache for later display.

## Test plan

- Open an alert, preprod or prod acess, click "download all" → ZIP contains every detection of the
  sequence, no CORS error in the console.
- Same for "download all + bounding boxes".
- Network tab: one GET per image, none served from cache.

Happy to discuss it and receive your feedbacks 🙏 