### PR TITLE
feat: add IGN Topo (SCAN 25) base layer

### DIFF
--- a/public/config/app-config.js
+++ b/public/config/app-config.js
@@ -21,4 +21,10 @@ window.AppConfig = {
     es: 'https://pyronear.notion.site/Gu-a-de-uso-de-la-plataforma-Pyronear-389425b6366881e69fd6f6f1a414814d',
   },
   HISTORY_NB_ALERTS_PER_PAGE: 15,
+
+  // IGN Géoplateforme key (https://data.geopf.fr/private/wmts).
+  // If empty, the IGN Topo base layer is hidden.
+  // The key is referrer-restricted: every origin serving the app (localhost, preprod,
+  // prod) must be allow-listed in the IGN client space, or tiles come back 401.
+  IGN_API_KEY: '',
 };

--- a/src/components/Common/Map/MapLayerControl.tsx
+++ b/src/components/Common/Map/MapLayerControl.tsx
@@ -17,7 +17,11 @@ import {
 } from '@mui/material';
 import { useState } from 'react';
 
-import { type BaseLayerType, useMapLayers } from '@/utils/useMapLayers';
+import {
+  type BaseLayerType,
+  isTopoIgnAvailable,
+  useMapLayers,
+} from '@/utils/useMapLayers';
 import { useTranslationPrefix } from '@/utils/useTranslationPrefix';
 
 import { DfciGridOverlay } from './DfciGridOverlay';
@@ -54,6 +58,7 @@ export const MapLayerControl = ({
   const [expanded, setExpanded] = useState(false);
   const [dfciEnabled, setDfciEnabled] = useState(false);
   const [onfForestEnabled, setOnfForestEnabled] = useState(false);
+  const topoIgnAvailable = isTopoIgnAvailable();
 
   const handleBaseLayerChange = (
     _: React.MouseEvent<HTMLElement>,
@@ -137,6 +142,14 @@ export const MapLayerControl = ({
                       label={tPrefs('mapIgn')}
                     />
                   </ToggleButton>
+                  {topoIgnAvailable && (
+                    <ToggleButton value="topo_ign">
+                      <LayerButton
+                        icon={<TerrainIcon fontSize="small" />}
+                        label={tPrefs('mapTopoIgn')}
+                      />
+                    </ToggleButton>
+                  )}
                   <ToggleButton value="satellite">
                     <LayerButton
                       icon={<SatelliteAltIcon fontSize="small" />}

--- a/src/components/Common/Map/TemplateMap.tsx
+++ b/src/components/Common/Map/TemplateMap.tsx
@@ -99,6 +99,7 @@ export const TemplateMap = ({
         attribution={baseTileConfig.attribution}
         url={baseTileConfig.url}
         maxZoom={baseTileConfig.maxZoom}
+        maxNativeZoom={baseTileConfig.maxNativeZoom}
       />
       <MapSizeInvalidator />
 

--- a/src/components/Topbar/Preferences/PreferencesMenu.tsx
+++ b/src/components/Topbar/Preferences/PreferencesMenu.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/context/useAuth';
 import { usePreferences } from '@/context/usePreferences';
 import appConfig from '@/services/appConfig';
+import { type BaseLayerType, isTopoIgnAvailable } from '@/utils/useMapLayers';
 
 import { AlertVolumeToggle } from './AlertVolumeToggle';
 
@@ -43,7 +44,7 @@ export const PreferencesMenu: React.FC<PreferencesMenuProps> = ({
 
   const handleMapBaseLayerChange = (
     _: React.MouseEvent<HTMLElement>,
-    value: 'osm' | 'ign' | 'satellite' | null
+    value: BaseLayerType | null
   ) => {
     if (value !== null) {
       updatePreferences({ map: { baseLayer: value } });
@@ -87,6 +88,12 @@ export const PreferencesMenu: React.FC<PreferencesMenuProps> = ({
                 <TerrainIcon fontSize="small" sx={{ mr: 0.5 }} />
                 {t('preferences.mapIgn')}
               </ToggleButton>
+              {isTopoIgnAvailable() && (
+                <ToggleButton value="topo_ign">
+                  <TerrainIcon fontSize="small" sx={{ mr: 0.5 }} />
+                  {t('preferences.mapTopoIgn')}
+                </ToggleButton>
+              )}
               <ToggleButton value="satellite">
                 <SatelliteAltIcon fontSize="small" sx={{ mr: 0.5 }} />
                 {t('preferences.mapSatellite')}

--- a/src/context/PreferencesContext.tsx
+++ b/src/context/PreferencesContext.tsx
@@ -1,9 +1,11 @@
 import { createContext } from 'react';
 
+import type { BaseLayerType } from '@/services/preferences';
+
 export interface UserPreferences {
   language: string;
   map: {
-    baseLayer: 'osm' | 'ign' | 'satellite';
+    baseLayer: BaseLayerType;
   };
   audio: {
     alertsEnabled: boolean;

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -210,6 +210,7 @@
     "mapBaseLayer": "Kart Base Layer",
     "mapOsm": "OpenStreetMap",
     "mapIgn": "IGN (France)",
+    "mapTopoIgn": "IGN Topo (France)",
     "mapSatellite": "Satellit",
     "enableAudioAlerts": "Audio-Warnungen aktivieren",
     "userGuide": "Benutzerhandbuch"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -209,6 +209,7 @@
     "mapBaseLayer": "Map Base Layer",
     "mapOsm": "OpenStreetMap",
     "mapIgn": "IGN (France)",
+    "mapTopoIgn": "IGN Topo (France)",
     "mapSatellite": "Satellite",
     "enableAudioAlerts": "Enable Audio Alerts",
     "userGuide": "User guide"

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -209,6 +209,7 @@
     "mapBaseLayer": "Capa base del mapa",
     "mapOsm": "OpenStreetMap",
     "mapIgn": "IGN (Francia)",
+    "mapTopoIgn": "IGN Topo (Francia)",
     "mapSatellite": "Satélite",
     "enableAudioAlerts": "Activar el sonido de las alertas",
     "userGuide": "Guía del usuario"

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -211,6 +211,7 @@
     "mapBaseLayer": "Fond de carte",
     "mapOsm": "OpenStreetMap",
     "mapIgn": "IGN (France)",
+    "mapTopoIgn": "IGN Topo (France)",
     "mapSatellite": "Satellite",
     "enableAudioAlerts": "Activer le son des alertes",
     "userGuide": "Guide utilisateur"

--- a/src/services/appConfig.ts
+++ b/src/services/appConfig.ts
@@ -19,6 +19,9 @@ export interface AppConfigType {
   readonly USER_GUIDE_URLS: Record<string, string>;
 
   readonly HISTORY_NB_ALERTS_PER_PAGE: number;
+
+  /** IGN Géoplateforme key. Empty => public IGN layers only. */
+  readonly IGN_API_KEY: string;
 }
 
 export class AppConfig {
@@ -66,6 +69,8 @@ export class AppConfig {
       USER_GUIDE_URLS: window.AppConfig?.USER_GUIDE_URLS,
       // @ts-expect-error config is fetched from a JS file
       HISTORY_NB_ALERTS_PER_PAGE: window.AppConfig?.HISTORY_NB_ALERTS_PER_PAGE,
+      // @ts-expect-error config is fetched from a JS file
+      IGN_API_KEY: window.AppConfig?.IGN_API_KEY ?? '',
     };
   }
 }

--- a/src/services/preferences.ts
+++ b/src/services/preferences.ts
@@ -1,9 +1,13 @@
 import { z } from 'zod';
 
+export const BASE_LAYERS = ['osm', 'ign', 'satellite', 'topo_ign'] as const;
+
+export type BaseLayerType = (typeof BASE_LAYERS)[number];
+
 export const UserPreferencesSchema = z.object({
   language: z.enum(['en', 'es', 'fr']),
   map: z.object({
-    baseLayer: z.enum(['osm', 'ign', 'satellite']),
+    baseLayer: z.enum(BASE_LAYERS),
   }),
   audio: z.object({
     alertsEnabled: z.boolean(),

--- a/src/utils/useMapLayers.ts
+++ b/src/utils/useMapLayers.ts
@@ -1,14 +1,31 @@
 import { useMemo } from 'react';
 
 import { usePreferences } from '@/context/usePreferences';
+import appConfig from '@/services/appConfig';
+import type { BaseLayerType } from '@/services/preferences';
+
+export type { BaseLayerType };
 
 export interface TileLayerConfig {
   url: string;
   attribution: string;
   maxZoom?: number;
+  /** Deepest zoom the service actually serves; deeper zooms upscale tiles. */
+  maxNativeZoom?: number;
 }
 
-export type BaseLayerType = 'osm' | 'ign' | 'satellite';
+/**
+ * SCAN 25 Touristique, served only by the private endpoint (JPEG, zoom 6-16).
+ *
+ * The key is referrer-restricted on the IGN side: every deployed origin must be
+ * allow-listed, and requests without a `Referer` are rejected with a 401. Leaflet
+ * loads tiles as `<img>`, so the browser default policy sends the origin and that
+ * is what IGN matches. Do not set a `referrerPolicy` on the TileLayer, and do not
+ * add `Referrer-Policy: no-referrer` (or `same-origin`) to the nginx config —
+ * either one strips the header and the layer goes blank.
+ */
+const buildTopoIgnUrl = (apiKey: string): string =>
+  `https://data.geopf.fr/private/wmts?apikey=${apiKey}&SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN25TOUR&STYLE=normal&FORMAT=image/jpeg&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}`;
 
 const LAYER_CONFIGS: Record<BaseLayerType, TileLayerConfig> = {
   osm: {
@@ -28,7 +45,20 @@ const LAYER_CONFIGS: Record<BaseLayerType, TileLayerConfig> = {
       '&copy; <a href="https://www.esri.com/">Esri</a>, Maxar, Earthstar Geographics',
     maxZoom: 19,
   },
+  // SCAN 25 Touristique: only served up to zoom 16, deeper zooms upscale.
+  // The url is built per-render from the configured key, see useMapLayers.
+  topo_ign: {
+    url: '',
+    attribution:
+      '&copy; <a href="https://www.ign.fr/">IGN</a> — SCAN 25&reg;, copie et reproduction interdites',
+    maxZoom: 19,
+    maxNativeZoom: 16,
+  },
 };
+
+/** The topo layer is only offered when a key is configured. */
+export const isTopoIgnAvailable = (): boolean =>
+  Boolean(appConfig.getConfig().IGN_API_KEY);
 
 export const DFCI_LAYER_CONFIG: TileLayerConfig = {
   url: 'https://data.geopf.fr/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=GEOGRAPHICALGRIDSYSTEM.DFCI&STYLE=normal&FORMAT=image/png&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}',
@@ -58,10 +88,18 @@ export const ONF_FOREST_LAYER_CONFIG: WmsLayerConfig = {
 export const useMapLayers = () => {
   const { preferences, updatePreferences } = usePreferences();
 
-  const baseTileConfig = useMemo(
-    () => LAYER_CONFIGS[preferences.map.baseLayer],
-    [preferences.map.baseLayer]
-  );
+  const baseTileConfig = useMemo(() => {
+    const apiKey = appConfig.getConfig().IGN_API_KEY;
+
+    // A stored topo_ign preference is meaningless without a key: fall back.
+    if (preferences.map.baseLayer === 'topo_ign') {
+      return apiKey
+        ? { ...LAYER_CONFIGS.topo_ign, url: buildTopoIgnUrl(apiKey) }
+        : LAYER_CONFIGS.ign;
+    }
+
+    return LAYER_CONFIGS[preferences.map.baseLayer];
+  }, [preferences.map.baseLayer]);
 
   const updateBaseLayer = (layer: BaseLayerType) => {
     updatePreferences({ map: { baseLayer: layer } });


### PR DESCRIPTION
## Context & Obj

Some frenc  users asked for SCAN 25 ign layer that shows terrain, trails and forest detail that the current IGN plan layer doesn't. Also, those users are used to work with it !

So this PR adds an "IGN Topo" base layer (IGN SCAN 25 Touristique) to the map layer control and the preferences menu.


## Config 

The layer relies on an IGN Géoplateforme API key, set as `IGN_API_KEY` in `app-config.js`.

- **Deployed without a key: the layer simply does not appear.** No error, no broken tile, the option is hidden, and a stored `topo_ign` preference falls back to the standard IGN layer.
- The key is **referrer-restricted** on the IGN side. Every origin serving the app (localhost, preprod, prod) must be allow-listed there, otherwise tiles come back `401`. A request with no `Referer` at all is also rejected, so don't add `Referrer-Policy: no-referrer` to nginx or a `referrerPolicy` to the TileLayer.

## Notes

- SCAN 25 is only served to zoom 16; deeper zooms upscale via `maxNativeZoom`.
- `BASE_LAYERS` in `services/preferences.ts` is now the single source of truth for the base-layer union (schema, context type and `BaseLayerType` derive from it).

Happy to discuss it and get your review, as a not react expert, I have been helped by Claude code to do it 

<img width="1380" height="922" alt="Capture d’écran 2026-08-06 à 18 34 53" src="https://github.com/user-attachments/assets/358c3f49-8425-47aa-b0c2-3808c24636f2" />

<img width="633" height="135" alt="Capture d’écran 2026-08-06 à 18 35 06" src="https://github.com/user-attachments/assets/ad4c8c78-20af-4b3d-bd1a-024bcd9a5a5d" />

